### PR TITLE
fix(intel): Swift and TypeScript declarations, configuration DataNode paths

### DIFF
--- a/.alef-generation.toml
+++ b/.alef-generation.toml
@@ -11,4 +11,4 @@
 # Do not hand-edit; it is rewritten by `alef generate`/`alef all` on every successful run.
 
 [crates]
-tree-sitter-language-pack = "d93bc82dba939e7073653dc369f0578e57275d825274cc0e035e46ffe2ebd1fa"
+tree-sitter-language-pack = "926c9772ab8c03e898225e9de7aa97f659c46ac2220190ddf8858dbf77a11ab8"

--- a/crates/ts-pack-core/src/intel/data_extraction.rs
+++ b/crates/ts-pack-core/src/intel/data_extraction.rs
@@ -402,16 +402,27 @@ fn toml_table_array_node(node: &Node, source: &str, depth: usize, truncated: &mu
     })
 }
 
+/// Join a TOML key's segments with `.`, without recursing per segment.
+///
+/// The grammar nests a `dotted_key` one level per segment, so a valid
+/// 10,000-segment key is a 10,000-level subtree. It sits inside a single pair,
+/// which is why the depth guard the tree builders share never sees it; a
+/// recursive join walked off a 2 MiB stack and aborted the process instead of
+/// producing a long string. The explicit stack below lives on the heap, so the
+/// key's length is the only cost. ~keep
 fn toml_key(node: &Node, source: &str) -> String {
-    if node.kind() == "dotted_key" {
-        let mut cursor = node.walk();
-        node.named_children(&mut cursor)
-            .map(|child| toml_key(&child, source))
-            .collect::<Vec<_>>()
-            .join(".")
-    } else {
-        strip_quotes(node_text(node, source)).to_string()
+    let mut segments = Vec::new();
+    let mut pending = vec![*node];
+    while let Some(current) = pending.pop() {
+        if current.kind() == "dotted_key" {
+            let mut cursor = current.walk();
+            let children: Vec<Node> = current.named_children(&mut cursor).collect();
+            pending.extend(children.into_iter().rev());
+        } else {
+            segments.push(strip_quotes(node_text(&current, source)));
+        }
     }
+    segments.join(".")
 }
 
 fn extract_properties(root: &Node, source: &str) -> Option<DataNode> {

--- a/crates/ts-pack-core/src/intel/data_extraction.rs
+++ b/crates/ts-pack-core/src/intel/data_extraction.rs
@@ -769,7 +769,7 @@ fn yaml_mapping_pair(node: &Node, source: &str, depth: usize, truncated: &mut us
                 });
             }
         }
-        let value = Some(strip_quotes(node_text(&val, source)).to_string());
+        let value = Some(yaml_scalar_text(&val, source));
         return Some(DataNode {
             kind: DataNodeKind::KeyValue,
             key,
@@ -790,9 +790,14 @@ fn yaml_mapping_pair(node: &Node, source: &str, depth: usize, truncated: &mut us
     })
 }
 
+/// The path segment a YAML key contributes, or `None` for a structured key.
+///
+/// An alias key (`*name : value`) is kept as its alias text: its source holds
+/// no nested values to leak into the key, and dropping the pair would lose the
+/// value it maps to.
 fn yaml_scalar_key(node: &Node, source: &str) -> Option<String> {
     match node.kind() {
-        "plain_scalar" | "single_quote_scalar" | "double_quote_scalar" | "block_scalar" => {
+        "plain_scalar" | "single_quote_scalar" | "double_quote_scalar" | "block_scalar" | "alias" => {
             Some(strip_quotes(node_text(node, source)).to_string())
         }
         "flow_node" | "block_node" => {
@@ -802,6 +807,21 @@ fn yaml_scalar_key(node: &Node, source: &str) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// The scalar text of a YAML value, without the anchor or tag that may precede it.
+///
+/// `name: &key value` wraps the scalar in a `flow_node` whose first named child
+/// is the anchor; the value is the content beside it, not the whole span.
+fn yaml_scalar_text(node: &Node, source: &str) -> String {
+    let mut cursor = node.walk();
+    let content = if matches!(node.kind(), "flow_node" | "block_node") {
+        node.named_children(&mut cursor)
+            .find(|child| !matches!(child.kind(), "anchor" | "tag"))
+    } else {
+        None
+    };
+    strip_quotes(node_text(content.as_ref().unwrap_or(node), source)).to_string()
 }
 
 fn yaml_sequence_items(node: &Node, source: &str, depth: usize, truncated: &mut usize) -> Vec<DataNode> {
@@ -824,10 +844,12 @@ fn yaml_sequence_items(node: &Node, source: &str, depth: usize, truncated: &mut 
         };
         let value = if sub.is_empty() {
             let mut c2 = child.walk();
-            child
-                .named_children(&mut c2)
-                .next()
-                .map(|n| strip_quotes(node_text(&n, source)).to_string())
+            let content = if child.kind() == "flow_node" {
+                Some(child)
+            } else {
+                child.named_children(&mut c2).next()
+            };
+            content.map(|n| yaml_scalar_text(&n, source))
         } else {
             None
         };

--- a/crates/ts-pack-core/src/intel/data_extraction.rs
+++ b/crates/ts-pack-core/src/intel/data_extraction.rs
@@ -7,7 +7,7 @@
 //! # Supported languages (cut-1)
 //!
 //! **Bucket A — field-named pair grammars:**
-//! `json`, `hjson`, `json5`, `toml`, `properties`, `hcl`, `hocon`, `kdl`
+//! `json`, `hjson`, `json5`, `toml`, `properties`, `hcl`, `terraform`, `hocon`, `kdl`
 //!
 //! **Bucket B — positional / two-child grammars:**
 //! `yaml`, `ini`, `editorconfig`, `csv`, `psv`, `po`, `nginx`, `caddy`
@@ -56,7 +56,7 @@ pub(crate) fn extract_data(root: &Node, source: &str, language: &str) -> Option<
         "json" | "hjson" | "json5" => extract_json(root, source, truncated),
         "toml" => extract_toml(root, source, truncated),
         "properties" => extract_properties(root, source),
-        "hcl" | "hocon" => extract_hcl(root, source, truncated),
+        "hcl" | "terraform" | "hocon" => extract_hcl(root, source, truncated),
         "kdl" => extract_kdl(root, source, truncated),
         "cue" => extract_cue(root, source, truncated),
         "yaml" => extract_yaml(root, source, truncated),
@@ -126,11 +126,18 @@ fn named_child_of_kind<'a>(node: &Node<'a>, kind: &str) -> Option<Node<'a>> {
 
 fn extract_json(root: &Node, source: &str, truncated: &mut usize) -> Option<DataNode> {
     let mut cursor = root.walk();
+    let mut result = None;
     for child in root.named_children(&mut cursor) {
-        let node = json_value_node(&child, source, None, 0, truncated);
-        if node.is_some() {
-            return node;
+        if let Some(node) = json_value_node(&child, source, None, 0, truncated) {
+            // The grammar accepts concatenated values, but they are not one JSON document.
+            if result.is_some() {
+                return None;
+            }
+            result = Some(node);
         }
+    }
+    if result.is_some() {
+        return result;
     }
     Some(DataNode {
         kind: DataNodeKind::KeyValue,
@@ -181,7 +188,9 @@ fn json_value_node(
                 .map(|n| strip_quotes(node_text(&n, source)).to_string());
             let v_node = node.child_by_field_name("value");
             if let Some(v) = v_node {
-                json_value_node(&v, source, k, depth + 1, truncated)
+                let mut value = json_value_node(&v, source, k, depth + 1, truncated)?;
+                value.span = span_from_node(node);
+                Some(value)
             } else {
                 None
             }
@@ -274,7 +283,7 @@ fn toml_pair_node(node: &Node, source: &str, depth: usize, truncated: &mut usize
         return None;
     }
     let key_node = &named[0];
-    let key = node_text(key_node, source).to_string();
+    let key = toml_key(key_node, source);
     if named.len() == 1 {
         return Some(DataNode {
             kind: DataNodeKind::KeyValue,
@@ -285,7 +294,7 @@ fn toml_pair_node(node: &Node, source: &str, depth: usize, truncated: &mut usize
             span: span_from_node(node),
         });
     }
-    let val_node = &named[named.len() - 1];
+    let val_node = named.iter().skip(1).find(|child| !child.is_extra())?;
     toml_value_node(val_node, source, Some(key), depth + 1, truncated)
 }
 
@@ -314,7 +323,11 @@ fn toml_value_node(
         "array" => {
             let mut result = Vec::new();
             let mut cursor = node.walk();
-            for (idx, child) in node.named_children(&mut cursor).enumerate() {
+            for (idx, child) in node
+                .named_children(&mut cursor)
+                .filter(|child| !child.is_extra())
+                .enumerate()
+            {
                 if let Some(n) = toml_value_node(&child, source, Some(idx.to_string()), depth + 1, truncated) {
                     result.push(n);
                 }
@@ -348,7 +361,7 @@ fn toml_table_node(node: &Node, source: &str, depth: usize, truncated: &mut usiz
     if named.is_empty() {
         return None;
     }
-    let key = node_text(&named[0], source).to_string();
+    let key = toml_key(&named[0], source);
     let children: Vec<DataNode> = named[1..]
         .iter()
         .filter(|c| c.kind() == "pair")
@@ -373,7 +386,7 @@ fn toml_table_array_node(node: &Node, source: &str, depth: usize, truncated: &mu
     if named.is_empty() {
         return None;
     }
-    let key = node_text(&named[0], source).to_string();
+    let key = toml_key(&named[0], source);
     let children: Vec<DataNode> = named[1..]
         .iter()
         .filter(|c| c.kind() == "pair")
@@ -387,6 +400,18 @@ fn toml_table_array_node(node: &Node, source: &str, depth: usize, truncated: &mu
         children,
         span: span_from_node(node),
     })
+}
+
+fn toml_key(node: &Node, source: &str) -> String {
+    if node.kind() == "dotted_key" {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor)
+            .map(|child| toml_key(&child, source))
+            .collect::<Vec<_>>()
+            .join(".")
+    } else {
+        strip_quotes(node_text(node, source)).to_string()
+    }
 }
 
 fn extract_properties(root: &Node, source: &str) -> Option<DataNode> {
@@ -498,7 +523,7 @@ fn hcl_block_node(node: &Node, source: &str, depth: usize, truncated: &mut usize
     let key_parts: Vec<&str> = named
         .iter()
         .filter(|n| n.kind() == "identifier" || n.kind() == "string_lit")
-        .map(|n| node_text(n, source))
+        .map(|n| strip_quotes(node_text(n, source)))
         .collect();
     let key = if key_parts.is_empty() {
         node_text(&named[0], source).to_string()
@@ -691,7 +716,7 @@ fn yaml_children(node: &Node, source: &str, depth: usize, truncated: &mut usize)
             "block_mapping" | "flow_mapping" => {
                 result.extend(yaml_children(&child, source, depth + 1, truncated));
             }
-            "block_sequence" => {
+            "block_sequence" | "flow_sequence" => {
                 let items = yaml_sequence_items(&child, source, depth + 1, truncated);
                 result.extend(items);
             }
@@ -714,10 +739,9 @@ fn yaml_mapping_pair(node: &Node, source: &str, depth: usize, truncated: &mut us
     let key_node = node.child_by_field_name("key");
     let val_node = node.child_by_field_name("value");
 
-    let key = key_node.map(|n| {
-        let raw = node_text(&n, source);
-        strip_quotes(raw).to_string()
-    });
+    // A structured YAML key has no scalar path. Copying its source into key
+    // would misclassify nested values as key metadata.
+    let key = Some(yaml_scalar_key(&key_node?, source)?);
 
     if let Some(val) = val_node {
         let val_kind = val.kind();
@@ -755,33 +779,55 @@ fn yaml_mapping_pair(node: &Node, source: &str, depth: usize, truncated: &mut us
     })
 }
 
+fn yaml_scalar_key(node: &Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "plain_scalar" | "single_quote_scalar" | "double_quote_scalar" | "block_scalar" => {
+            Some(strip_quotes(node_text(node, source)).to_string())
+        }
+        "flow_node" | "block_node" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .find_map(|child| yaml_scalar_key(&child, source))
+        }
+        _ => None,
+    }
+}
+
 fn yaml_sequence_items(node: &Node, source: &str, depth: usize, truncated: &mut usize) -> Vec<DataNode> {
     let mut result = Vec::new();
     if depth_exceeded(node, depth, truncated) {
         return result;
     }
     let mut cursor = node.walk();
-    for (idx, child) in node.named_children(&mut cursor).enumerate() {
-        if child.kind() == "block_sequence_item" {
-            let sub = yaml_children(&child, source, depth + 1, truncated);
-            let value = if sub.is_empty() {
-                let mut c2 = child.walk();
-                child
-                    .named_children(&mut c2)
-                    .next()
-                    .map(|n| strip_quotes(node_text(&n, source)).to_string())
-            } else {
-                None
-            };
-            result.push(DataNode {
-                kind: DataNodeKind::Sequence,
-                key: Some(idx.to_string()),
-                value,
-                attributes: vec![],
-                children: sub,
-                span: span_from_node(&child),
-            });
-        }
+    for (idx, child) in node
+        .named_children(&mut cursor)
+        .filter(|child| matches!(child.kind(), "block_sequence_item" | "flow_node" | "flow_pair"))
+        .enumerate()
+    {
+        let sub = if child.kind() == "flow_pair" {
+            yaml_mapping_pair(&child, source, depth + 1, truncated)
+                .into_iter()
+                .collect()
+        } else {
+            yaml_children(&child, source, depth + 1, truncated)
+        };
+        let value = if sub.is_empty() {
+            let mut c2 = child.walk();
+            child
+                .named_children(&mut c2)
+                .next()
+                .map(|n| strip_quotes(node_text(&n, source)).to_string())
+        } else {
+            None
+        };
+        result.push(DataNode {
+            kind: DataNodeKind::Sequence,
+            key: Some(idx.to_string()),
+            value,
+            attributes: vec![],
+            children: sub,
+            span: span_from_node(&child),
+        });
     }
     result
 }

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -158,7 +158,7 @@ impl<'a> Collector<'a> {
             self.exports.push(export);
         }
         if self.wanted.symbols
-            && let Some(symbol) = symbol_at(node, self.source)
+            && let Some(symbol) = symbol_at(node, self.source, self.language)
         {
             self.symbols.push(symbol);
         }

--- a/crates/ts-pack-core/src/intel/intelligence.rs
+++ b/crates/ts-pack-core/src/intel/intelligence.rs
@@ -670,7 +670,12 @@ pub(super) fn symbol_at(node: &tree_sitter::Node, source: &str, language: &str) 
                 || node
                     .child_by_field_name("value")
                     .and_then(unparenthesized)
-                    .is_some_and(|value| matches!(value.kind(), "arrow_function" | "function_expression"))
+                    .is_some_and(|value| {
+                        matches!(
+                            value.kind(),
+                            "arrow_function" | "function_expression" | "generator_function"
+                        )
+                    })
             {
                 return None;
             }
@@ -732,6 +737,9 @@ fn swift_nominal_kind(node: &tree_sitter::Node) -> Option<StructureKind> {
 }
 
 /// New constant declarations belong to file/type scope, not executable bodies.
+///
+/// Generators are their own node kinds in the JavaScript family, with or
+/// without `async`, so they are listed beside the plain function forms.
 fn in_declaration_scope(node: &tree_sitter::Node) -> bool {
     let mut parent = node.parent();
     while let Some(ancestor) = parent {
@@ -739,6 +747,8 @@ fn in_declaration_scope(node: &tree_sitter::Node) -> bool {
             ancestor.kind(),
             "function_declaration"
                 | "function_expression"
+                | "generator_function_declaration"
+                | "generator_function"
                 | "arrow_function"
                 | "method_definition"
                 | "function_body"

--- a/crates/ts-pack-core/src/intel/intelligence.rs
+++ b/crates/ts-pack-core/src/intel/intelligence.rs
@@ -525,17 +525,21 @@ fn export_specifier_names(node: &tree_sitter::Node, source: &str) -> Vec<String>
 /// matcher. Elixir definitions are handled by [`super::elixir::definition`].
 pub(super) fn structure_kind_at(node: &tree_sitter::Node, language: &str) -> Option<StructureKind> {
     match node.kind() {
-        "function_definition" | "function_declaration" | "function_item" | "arrow_function" => {
-            Some(StructureKind::Function)
-        }
+        "function_definition"
+        | "function_declaration"
+        | "protocol_function_declaration"
+        | "function_item"
+        | "arrow_function" => Some(StructureKind::Function),
         "method_definition" | "method_declaration" => Some(StructureKind::Method),
         "method" | "singleton_method" if language == "ruby" => Some(StructureKind::Method),
+        "class_declaration" if language == "swift" => swift_nominal_kind(node),
         "class_definition" | "class_declaration" | "class" => Some(StructureKind::Class),
         "struct_item" | "struct_definition" | "struct_declaration" => Some(StructureKind::Struct),
-        "interface_declaration" | "interface_definition" => Some(StructureKind::Interface),
+        "interface_declaration" | "interface_definition" | "protocol_declaration" => Some(StructureKind::Interface),
         "enum_item" | "enum_definition" | "enum_declaration" => Some(StructureKind::Enum),
         "module_definition" | "mod_item" | "package_header" | "package_declaration" => Some(StructureKind::Module),
         "module" if language == "ruby" => Some(StructureKind::Module),
+        "internal_module" if matches!(language, "typescript" | "tsx") => Some(StructureKind::Namespace),
         "trait_item" => Some(StructureKind::Trait),
         "impl_item" => Some(StructureKind::Impl),
         _ => None,
@@ -638,28 +642,114 @@ pub(super) fn has_wildcard_token(node: &tree_sitter::Node) -> bool {
 }
 
 /// Classify `node` as a symbol, if it is a named declaration.
-pub(super) fn symbol_at(node: &tree_sitter::Node, source: &str) -> Option<SymbolInfo> {
+pub(super) fn symbol_at(node: &tree_sitter::Node, source: &str, language: &str) -> Option<SymbolInfo> {
+    let mut declaration = *node;
     let symbol_kind = match node.kind() {
-        "function_definition" | "function_declaration" | "function_item" => SymbolKind::Function,
+        "function_definition" | "function_declaration" | "protocol_function_declaration" | "function_item" => {
+            SymbolKind::Function
+        }
+        "class_declaration" if language == "swift" => match swift_nominal_kind(node)? {
+            StructureKind::Struct => SymbolKind::Type,
+            StructureKind::Enum => SymbolKind::Enum,
+            StructureKind::Class => SymbolKind::Class,
+            _ => return None,
+        },
         "class_definition" | "class_declaration" => SymbolKind::Class,
-        "type_alias_declaration" | "type_item" => SymbolKind::Type,
+        "type_alias_declaration" | "typealias_declaration" | "type_item" => SymbolKind::Type,
         "type_spec" => go_type_spec_symbol_kind(node),
-        "interface_declaration" => SymbolKind::Interface,
+        "interface_declaration" | "protocol_declaration" => SymbolKind::Interface,
         "enum_item" | "enum_declaration" => SymbolKind::Enum,
         "const_item" | "const_declaration" => SymbolKind::Constant,
+        "variable_declarator" if matches!(language, "javascript" | "typescript" | "tsx") => {
+            let parent = node.parent()?;
+            if parent.kind() != "lexical_declaration"
+                || parent
+                    .child_by_field_name("kind")
+                    .is_none_or(|kind| kind.kind() != "const")
+                || !in_declaration_scope(node)
+                || node
+                    .child_by_field_name("value")
+                    .and_then(unparenthesized)
+                    .is_some_and(|value| matches!(value.kind(), "arrow_function" | "function_expression"))
+            {
+                return None;
+            }
+            SymbolKind::Constant
+        }
+        "pattern" if language == "swift" => {
+            declaration = node.parent()?;
+            if declaration.kind() != "property_declaration" || !in_declaration_scope(node) {
+                return None;
+            }
+            let mut cursor = declaration.walk();
+            if !declaration
+                .named_children(&mut cursor)
+                .any(|child| child.kind() == "value_binding_pattern" && node_text(&child, source) == "let")
+            {
+                return None;
+            }
+            SymbolKind::Constant
+        }
         "let_declaration" | "variable_declaration" | "lexical_declaration" => SymbolKind::Variable,
         _ => return None,
     };
-    let name_node = node.child_by_field_name("name")?;
+    let name_node = if node.kind() == "pattern" {
+        node.child_by_field_name("bound_identifier")?
+    } else {
+        node.child_by_field_name("name")?
+    };
+    if node.kind() == "variable_declarator" && name_node.kind() != "identifier" {
+        return None;
+    }
     Some(SymbolInfo {
         name: node_text(&name_node, source).to_string(),
         kind: symbol_kind,
-        span: span_from_node(node),
-        type_annotation: node
+        span: span_from_node(&declaration),
+        type_annotation: declaration
             .child_by_field_name("type")
             .map(|n| node_text(&n, source).to_string()),
-        doc: doc_comment_at(node, source),
+        doc: doc_comment_at(&declaration, source),
     })
+}
+
+/// Parentheses preserve an initializer's identity; calls and other expressions do not.
+fn unparenthesized(mut node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+    while node.kind() == "parenthesized_expression" {
+        node = node.named_child(0)?;
+    }
+    Some(node)
+}
+
+/// Swift uses one node kind for classes, structs, actors, extensions and enums.
+fn swift_nominal_kind(node: &tree_sitter::Node) -> Option<StructureKind> {
+    match node.child_by_field_name("declaration_kind")?.kind() {
+        "struct" => Some(StructureKind::Struct),
+        "extension" => Some(StructureKind::Impl),
+        "enum" => Some(StructureKind::Enum),
+        "class" | "actor" => Some(StructureKind::Class),
+        _ => None,
+    }
+}
+
+/// New constant declarations belong to file/type scope, not executable bodies.
+fn in_declaration_scope(node: &tree_sitter::Node) -> bool {
+    let mut parent = node.parent();
+    while let Some(ancestor) = parent {
+        if matches!(
+            ancestor.kind(),
+            "function_declaration"
+                | "function_expression"
+                | "arrow_function"
+                | "method_definition"
+                | "function_body"
+                | "lambda_literal"
+                | "computed_property"
+        ) {
+            return false;
+        }
+        parent = ancestor.parent();
+    }
+    true
 }
 
 /// Classify `node` as a syntax diagnostic, if it is an error or missing node.
@@ -688,6 +778,19 @@ pub(super) fn diagnostic_at(node: &tree_sitter::Node, source: &str) -> Option<Di
 /// `"identifier"` (Kotlin packages), then `"scoped_identifier"` (Java packages).
 /// Returns `None` if no non-empty text is found via any strategy.
 pub(super) fn resolve_structure_name(node: &tree_sitter::Node, source: &str) -> Option<String> {
+    if node.kind() == "arrow_function" {
+        let mut value = *node;
+        let mut parent = value.parent()?;
+        while parent.kind() == "parenthesized_expression" {
+            value = parent;
+            parent = value.parent()?;
+        }
+        if parent.kind() != "variable_declarator" || parent.child_by_field_name("value")?.id() != value.id() {
+            return None;
+        }
+        let name = parent.child_by_field_name("name")?;
+        return (name.kind() == "identifier").then(|| node_text(&name, source).to_string());
+    }
     if let Some(n) = node.child_by_field_name("name") {
         let text = node_text(&n, source);
         if !text.is_empty() {

--- a/crates/ts-pack-core/src/intel/legacy.rs
+++ b/crates/ts-pack-core/src/intel/legacy.rs
@@ -46,7 +46,7 @@ pub(super) fn extract_intelligence(source: &str, language: &str, tree: &tree_sit
     let mut docstrings = Vec::new();
     collect_docstrings(&root, source, language, &mut docstrings);
     let mut symbols = Vec::new();
-    collect_symbols(&root, source, &mut symbols);
+    collect_symbols(&root, source, language, &mut symbols);
     let mut diagnostics = Vec::new();
     collect_diagnostics(&root, source, &mut diagnostics);
 
@@ -206,13 +206,13 @@ fn collect_structure_call(
     true
 }
 
-fn collect_symbols(node: &tree_sitter::Node, source: &str, symbols: &mut Vec<SymbolInfo>) {
-    if let Some(symbol) = symbol_at(node, source) {
+fn collect_symbols(node: &tree_sitter::Node, source: &str, language: &str, symbols: &mut Vec<SymbolInfo>) {
+    if let Some(symbol) = symbol_at(node, source, language) {
         symbols.push(symbol);
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_symbols(&child, source, symbols);
+        collect_symbols(&child, source, language, symbols);
     }
 }
 

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -44,6 +44,37 @@ fn yaml_structured_keys_do_not_become_scalar_paths() {
 }
 
 #[test]
+fn yaml_alias_keys_are_preserved() {
+    let source =
+        "name: &key value\n*key : retained\nbase: &shape {nested: 1}\n*shape : kept\nlist:\n- &item one\n- *item\n";
+    let result =
+        process(source, &ProcessConfig::new("yaml").with_data_extraction(true)).expect("alias keys are valid YAML");
+    assert_eq!(result.metrics.error_count, 0, "fixture must parse without recovery");
+    let root = result.data.expect("yaml exposes data");
+    let entries: Vec<_> = root
+        .children
+        .iter()
+        .map(|node| (node.key.as_deref(), node.value.as_deref()))
+        .collect();
+    assert_eq!(
+        entries,
+        vec![
+            (Some("name"), Some("value")),
+            (Some("*key"), Some("retained")),
+            (Some("base"), None),
+            (Some("*shape"), Some("kept")),
+            (Some("list"), None),
+        ]
+    );
+    let items: Vec<_> = root.children[4]
+        .children
+        .iter()
+        .map(|node| node.value.as_deref())
+        .collect();
+    assert_eq!(items, vec![Some("one"), Some("*item")]);
+}
+
+#[test]
 fn toml_dotted_keys_follow_segments_instead_of_source_spacing() {
     let root = data(
         "service . \"connection\" = { retry . count = 3 }\n[profile . \"release\"]\nopt-level = 3\n",

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -1,3 +1,7 @@
+//! Regression coverage for configuration formats whose data tree lost paths, items or documents.
+#![allow(clippy::unwrap_used, clippy::expect_used)] // ~keep: a failed setup step in a test must abort loudly
+#![allow(clippy::print_stdout)] // ~keep: the deep-key probe reports to its parent process on stdout
+
 use tree_sitter_language_pack::{DataNode, ProcessConfig, process};
 
 fn data(source: &str, language: &str) -> DataNode {

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -135,3 +135,58 @@ fn json_multiple_roots_do_not_return_only_the_first() {
         "multiple roots must not yield a partial data tree"
     );
 }
+
+/// Set by the parent test so the child process runs the deep-key probe for real.
+const TOML_DEEP_KEY_PROBE_ENV: &str = "TSLP_TOML_DEEP_KEY_PROBE";
+const TOML_DEEP_KEY_SEGMENTS: usize = 10_000;
+const TOML_DEEP_KEY_SENTINEL: &str = "toml deep dotted key probe completed";
+
+/// The probe itself. Ignored so a plain run never executes it in-process: a stack
+/// overflow is an abort, not a panic, and would take every other test in this
+/// binary down with it. The parent below re-executes this binary with the env var
+/// set and asks for exactly this test.
+#[test]
+#[ignore]
+fn toml_deep_dotted_key_probe() {
+    if std::env::var_os(TOML_DEEP_KEY_PROBE_ENV).is_none() {
+        return;
+    }
+    let source = format!("{} = 1\n", vec!["a"; TOML_DEEP_KEY_SEGMENTS].join("."));
+    // ~keep 2 MiB is the smallest stack the library runs on (tokio spawn_blocking and the
+    // ~keep Node, Python and JVM worker threads); the default test thread is not that small.
+    let worker = std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || data(&source, "toml"))
+        .expect("spawn probe thread");
+    let root = worker.join().expect("probe thread must not panic");
+    assert_eq!(root.children.len(), 1);
+    let key = root.children[0].key.as_deref().expect("dotted key");
+    assert_eq!(key.split('.').count(), TOML_DEEP_KEY_SEGMENTS);
+    assert!(key.split('.').all(|segment| segment == "a"));
+    println!("{TOML_DEEP_KEY_SENTINEL}");
+}
+
+/// A valid 10,000-segment dotted key must not abort the process.
+///
+/// The TOML grammar nests one `dotted_key` node per segment, so a key builder that
+/// recurses per segment walks off a 2 MiB stack long before the depth guard the
+/// other builders share can see it. An abort cannot be caught in-process, so the
+/// probe runs in a child and this test reads its exit status and its sentinel line;
+/// the sentinel is what stops a filtered-out or silently skipped probe from passing
+/// as a survival.
+#[test]
+fn toml_deep_dotted_key_survives_a_two_mebibyte_stack() {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = std::process::Command::new(exe)
+        .args(["--ignored", "--exact", "toml_deep_dotted_key_probe", "--nocapture"])
+        .env(TOML_DEEP_KEY_PROBE_ENV, "1")
+        .output()
+        .expect("spawn the probe child process");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success() && stdout.contains(TOML_DEEP_KEY_SENTINEL),
+        "the deep dotted key probe did not survive (status {:?})\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status
+    );
+}

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -1,0 +1,137 @@
+use tree_sitter_language_pack::{DataNode, ProcessConfig, process};
+
+fn data(source: &str, language: &str) -> DataNode {
+    process(source, &ProcessConfig::new(language).with_data_extraction(true))
+        .expect("valid configuration must parse")
+        .data
+        .expect("supported configuration must expose data")
+}
+
+#[test]
+fn yaml_flow_sequences_preserve_item_keys_and_spans() {
+    let source = "services: [{name: first}, {port: 80}]\n";
+    let root = data(source, "yaml");
+    let services = &root.children[0];
+    assert_eq!(services.key.as_deref(), Some("services"));
+    assert_eq!(services.children.len(), 2);
+    for (index, item) in services.children.iter().enumerate() {
+        assert_eq!(item.key.as_deref(), Some(index.to_string().as_str()));
+        assert_eq!(item.children.len(), 1);
+        assert_eq!(item.span.start_line, 0);
+        assert_eq!(item.span.end_line, 0);
+    }
+    assert_eq!(services.children[0].children[0].key.as_deref(), Some("name"));
+    assert_eq!(services.children[1].children[0].key.as_deref(), Some("port"));
+}
+
+#[test]
+fn yaml_flow_sequence_comments_do_not_change_ordinals() {
+    let root = data(
+        "services: [\n  # comment\n  {name: first},\n  # another comment\n  {name: second}\n]\n",
+        "yaml",
+    );
+    let items = &root.children[0].children;
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].key.as_deref(), Some("0"));
+    assert_eq!(items[1].key.as_deref(), Some("1"));
+}
+
+#[test]
+fn yaml_structured_keys_do_not_become_scalar_paths() {
+    let root = data("? {nested: VALUE_SENTINEL}\n: ignored\nsafe: true\n", "yaml");
+    let keys: Vec<_> = root.children.iter().filter_map(|node| node.key.as_deref()).collect();
+    assert_eq!(keys, ["safe"]);
+}
+
+#[test]
+fn toml_dotted_keys_follow_segments_instead_of_source_spacing() {
+    let root = data(
+        "service . \"connection\" = { retry . count = 3 }\n[profile . \"release\"]\nopt-level = 3\n",
+        "toml",
+    );
+    assert_eq!(root.children[0].key.as_deref(), Some("service.connection"));
+    assert_eq!(root.children[0].children[0].key.as_deref(), Some("retry.count"));
+    assert_eq!(root.children[1].key.as_deref(), Some("profile.release"));
+}
+
+#[test]
+fn toml_array_comments_do_not_change_ordinals() {
+    let root = data(
+        "items = [\n {name = \"first\"},\n # comment\n {name = \"second\"}\n]\n",
+        "toml",
+    );
+    let items = &root.children[0].children;
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].key.as_deref(), Some("0"));
+    assert_eq!(items[1].key.as_deref(), Some("1"));
+    assert_eq!(items[1].span.start_line, 3);
+}
+
+#[test]
+fn json_property_span_includes_the_key_before_a_multiline_value() {
+    let source = "{\n \"properties\":\n {\"enabled\": true}\n}\n";
+    let root = data(source, "json");
+    let property = &root.children[0];
+    assert_eq!(property.key.as_deref(), Some("properties"));
+    assert_eq!(property.span.start_line, 1);
+    assert_eq!(
+        &source[property.span.start_byte..property.span.end_byte],
+        "\"properties\":\n {\"enabled\": true}"
+    );
+}
+
+#[test]
+fn terraform_uses_the_generic_hcl_data_adapter() {
+    let source = "resource \"aws_ecs_service\" \"app\" {\n  desired_count = 1\n}\n";
+    let hcl = data(source, "hcl");
+    let terraform = data(source, "terraform");
+    assert_eq!(terraform.children.len(), 1);
+    assert_eq!(terraform.children[0].key, hcl.children[0].key);
+    let span = &terraform.children[0].span;
+    assert_eq!((span.start_line, span.end_line), (0, 2));
+    assert_eq!(&source[span.start_byte..span.end_byte], source.trim_end());
+}
+
+#[test]
+fn hcl_block_labels_are_key_segments_without_quotes() {
+    let root = data("resource \"aws_ecs_service\" \"app\" {}\n", "hcl");
+    assert_eq!(root.children[0].key.as_deref(), Some("resource.aws_ecs_service.app"));
+}
+
+#[test]
+fn toml_trailing_comments_preserve_container_children_and_spans() {
+    let source = "service = {retry = 3} # note\nitems = [\n {name = \"first\"},\n {name = \"second\"}\n] # note\n";
+    let root = data(source, "toml");
+    assert_eq!(root.children[0].children.len(), 1);
+    assert_eq!(root.children[0].children[0].key.as_deref(), Some("retry"));
+    let items = &root.children[1];
+    assert_eq!(items.children.len(), 2);
+    assert_eq!((items.span.start_line, items.span.end_line), (1, 4));
+    assert_eq!(items.children[1].children[0].key.as_deref(), Some("name"));
+}
+
+#[test]
+fn yaml_shorthand_flow_mappings_preserve_ordinals_and_keys() {
+    let root = data("items: [foo: bar, baz: quux]\n", "yaml");
+    let items = &root.children[0].children;
+    assert_eq!(items.len(), 2);
+    for (index, key) in ["foo", "baz"].iter().enumerate() {
+        assert_eq!(items[index].key.as_deref(), Some(index.to_string().as_str()));
+        assert_eq!(items[index].children[0].key.as_deref(), Some(*key));
+    }
+}
+
+#[test]
+fn json_multiple_roots_do_not_return_only_the_first() {
+    assert_eq!(data("{\"a\":1}\n", "json").children[0].key.as_deref(), Some("a"));
+    let result = process(
+        "{\"a\":1}\n{\"b\":2}\n",
+        &ProcessConfig::new("json").with_data_extraction(true),
+    )
+    .expect("the grammar accepts multiple roots");
+    assert_eq!(result.metrics.error_count, 0);
+    assert!(
+        result.data.is_none(),
+        "multiple roots must not yield a partial data tree"
+    );
+}

--- a/crates/ts-pack-core/tests/declaration_intelligence.rs
+++ b/crates/ts-pack-core/tests/declaration_intelligence.rs
@@ -226,3 +226,16 @@ fn typescript_namespace_supplies_the_exact_owner_span_for_alias_symbols() {
         assert_eq!((alias.span.start_line, alias.span.end_line), (1, 1));
     }
 }
+
+#[test]
+fn generator_bodies_are_not_declaration_scope() {
+    let source = "const KEPT = 5;\nfunction* gen() {\n  const local = 1;\n  yield local;\n}\nasync function* agen() {\n  const inner = 2;\n  yield inner;\n}\nconst plain = function* () {\n  const expr = 3;\n  yield expr;\n};\nconst asyncPlain = async function* () {\n  const aexpr = 4;\n  yield aexpr;\n};\nfunction control() {\n  const ordinary = 6;\n  return ordinary;\n}\n";
+    let result = extract(source, "javascript");
+    let constants: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|symbol| symbol.kind == SymbolKind::Constant)
+        .map(|symbol| symbol.name.as_str())
+        .collect();
+    assert_eq!(constants, vec!["KEPT"]);
+}

--- a/crates/ts-pack-core/tests/declaration_intelligence.rs
+++ b/crates/ts-pack-core/tests/declaration_intelligence.rs
@@ -1,0 +1,228 @@
+//! Regression coverage for declarations whose grammar shape differs from its name.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureKind, SymbolKind, process};
+
+fn extract(source: &str, language: &str) -> ProcessResult {
+    let result = process(source, &ProcessConfig::new(language).all())
+        .expect("real grammar required; build with TSLP_LANGUAGES=swift,typescript,tsx,javascript");
+    assert_eq!(result.metrics.error_count, 0, "fixture must parse without recovery");
+    result
+}
+
+#[test]
+fn swift_protocols_have_names_kinds_spans_and_nested_requirements() {
+    let source = "public protocol SigningKey: Sendable {\n  func sign()\n}\npublic protocol KeyStorage: Sendable {}\nprotocol Callable: AnyObject {}\n";
+    let result = extract(source, "swift");
+    let structures: Vec<_> = result
+        .structure
+        .iter()
+        .map(|item| {
+            (
+                item.name.as_deref(),
+                &item.kind,
+                item.span.start_line,
+                item.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        structures,
+        vec![
+            (Some("SigningKey"), &StructureKind::Interface, 0, 2),
+            (Some("KeyStorage"), &StructureKind::Interface, 3, 3),
+            (Some("Callable"), &StructureKind::Interface, 4, 4),
+        ]
+    );
+    assert_eq!(result.structure[0].children[0].name.as_deref(), Some("sign"));
+    assert_eq!(result.structure[0].children[0].span.start_line, 1);
+    assert_eq!(result.structure[0].children[0].span.end_line, 1);
+    for (name, start, end) in [("SigningKey", 0, 2), ("KeyStorage", 3, 3), ("Callable", 4, 4)] {
+        let symbol = result.symbols.iter().find(|symbol| symbol.name == name).unwrap();
+        assert_eq!(symbol.kind, SymbolKind::Interface);
+        assert_eq!((symbol.span.start_line, symbol.span.end_line), (start, end));
+    }
+}
+
+#[test]
+fn swift_nominal_declarations_preserve_struct_actor_and_extension_identity() {
+    let source = "struct Keys {\n  func lookup() {}\n}\nactor Store {}\nextension Keys {\n  func fetch() {}\n}\n";
+    let result = extract(source, "swift");
+    let structures: Vec<_> = result
+        .structure
+        .iter()
+        .map(|item| {
+            (
+                item.name.as_deref(),
+                &item.kind,
+                item.span.start_line,
+                item.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        structures,
+        vec![
+            (Some("Keys"), &StructureKind::Struct, 0, 2),
+            (Some("Store"), &StructureKind::Class, 3, 3),
+            (Some("Keys"), &StructureKind::Impl, 4, 6),
+        ]
+    );
+    assert_eq!(result.structure[2].children[0].name.as_deref(), Some("fetch"));
+}
+
+#[test]
+fn swift_aliases_and_constants_are_symbols_without_function_local_bindings() {
+    let source = "typealias KeyID = String\nlet retryLimit: Int = 3\nstruct Keys {\n  static let shared = 1\n  func lookup() {\n    let local = 2\n  }\n}\n";
+    let result = extract(source, "swift");
+    let symbols: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|symbol| matches!(symbol.kind, SymbolKind::Type | SymbolKind::Constant))
+        .map(|symbol| {
+            (
+                symbol.name.as_str(),
+                &symbol.kind,
+                symbol.span.start_line,
+                symbol.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        symbols,
+        vec![
+            ("KeyID", &SymbolKind::Type, 0, 0),
+            ("retryLimit", &SymbolKind::Constant, 1, 1),
+            ("Keys", &SymbolKind::Type, 2, 7),
+            ("shared", &SymbolKind::Constant, 3, 3),
+        ]
+    );
+    assert!(!result.symbols.iter().any(|symbol| symbol.name == "local"));
+}
+
+#[test]
+fn typescript_module_constants_and_aliases_exclude_local_variables_and_keep_each_binding() {
+    let source = "export type KeyID = string;\nexport const LIMIT: number = 3, SECOND = 4;\nconst CONFIG = { retries: 2 };\nfunction run() {\n  const local = 1;\n  return local;\n}\n";
+    let result = extract(source, "typescript");
+    let symbols: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|symbol| matches!(symbol.kind, SymbolKind::Type | SymbolKind::Constant))
+        .map(|symbol| {
+            (
+                symbol.name.as_str(),
+                &symbol.kind,
+                symbol.span.start_line,
+                symbol.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        symbols,
+        vec![
+            ("KeyID", &SymbolKind::Type, 0, 0),
+            ("LIMIT", &SymbolKind::Constant, 1, 1),
+            ("SECOND", &SymbolKind::Constant, 1, 1),
+            ("CONFIG", &SymbolKind::Constant, 2, 2),
+        ]
+    );
+    assert!(!result.symbols.iter().any(|symbol| symbol.name == "local"));
+    for (name, declaration) in [
+        ("LIMIT", "LIMIT: number = 3"),
+        ("SECOND", "SECOND = 4"),
+        ("CONFIG", "CONFIG = { retries: 2 }"),
+    ] {
+        let symbol = result.symbols.iter().find(|symbol| symbol.name == name).unwrap();
+        assert_eq!(&source[symbol.span.start_byte..symbol.span.end_byte], declaration);
+    }
+}
+
+#[test]
+fn named_arrow_bindings_keep_identity_inside_components_and_callbacks_stay_anonymous() {
+    let source = "export function Panel() {\n  const loadItems = async () => {\n    return 1;\n  };\n  consume(async () => {\n    await loadItems();\n  });\n  const select = value => value;\n  return <div />;\n}\n";
+    let result = extract(source, "tsx");
+    let component = &result.structure[0];
+    let children: Vec<_> = component
+        .children
+        .iter()
+        .map(|item| {
+            (
+                item.name.as_deref(),
+                &item.kind,
+                item.span.start_line,
+                item.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        children,
+        vec![
+            (Some("loadItems"), &StructureKind::Function, 1, 3),
+            (None, &StructureKind::Function, 4, 6),
+            (Some("select"), &StructureKind::Function, 7, 7),
+        ]
+    );
+}
+
+#[test]
+fn destructuring_patterns_do_not_become_literal_containing_symbol_names() {
+    let source = "const KEPT = 1;\nconst { limit = 7 } = config;\nconst [first = 9] = values;\n";
+    let result = extract(source, "typescript");
+    let symbols: Vec<_> = result
+        .symbols
+        .iter()
+        .map(|symbol| (symbol.name.as_str(), &symbol.kind))
+        .collect();
+    assert_eq!(symbols, vec![("KEPT", &SymbolKind::Constant)]);
+}
+
+#[test]
+fn arrow_bindings_are_functions_without_constant_duplicates_or_parameter_names() {
+    let source = "const convert = item => item;\nconst wrapped = (() => 1);\nconsume(value => value);\n";
+    let result = extract(source, "typescript");
+    let names: Vec<_> = result.structure.iter().map(|item| item.name.as_deref()).collect();
+    assert_eq!(names, vec![Some("convert"), Some("wrapped"), None]);
+    assert!(
+        result.symbols.is_empty(),
+        "function-valued bindings must not also emit constant symbols"
+    );
+}
+
+#[test]
+fn typescript_namespace_supplies_the_exact_owner_span_for_alias_symbols() {
+    let source = "namespace Domain {\n  export type ID = string; export type State = number;\n}\nexport const select = value => value;\n";
+    let result = extract(source, "typescript");
+    let structures: Vec<_> = result
+        .structure
+        .iter()
+        .map(|item| {
+            (
+                item.name.as_deref(),
+                &item.kind,
+                item.span.start_line,
+                item.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        structures,
+        vec![
+            (Some("Domain"), &StructureKind::Namespace, 0, 2),
+            (Some("select"), &StructureKind::Function, 3, 3),
+        ]
+    );
+    let owner = &result.structure[0].span;
+    let aliases: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|symbol| symbol.kind == SymbolKind::Type)
+        .collect();
+    assert_eq!(
+        aliases.iter().map(|symbol| symbol.name.as_str()).collect::<Vec<_>>(),
+        vec!["ID", "State"]
+    );
+    for alias in aliases {
+        assert!(alias.span.start_byte > owner.start_byte && alias.span.end_byte < owner.end_byte);
+        assert_eq!((alias.span.start_line, alias.span.end_line), (1, 1));
+    }
+}


### PR DESCRIPTION
Hello I'm back with one more patch, thank you for considering it and your ongoing efforts on this repo.

We use tree-sitter-language-pack to build symbol cards for a code index on both a server and a macOS client, and we need the two to agree on every declaration in a file. While checking that agreement we found a handful of cases where `intel` returned less than the source contained, so we added handling and a test for each. Two commits, one per area. They touch different files, so they can be reviewed together or split if you prefer.

In the spirit of your AI policy: Claude and Codex wrote most of this code. I planned the work and reviewed every change and the validation below.

## Related

None that we could find. Happy to open issues if you would like these tracked, and will be sure that future submits do that, just let me know.

## Description

**Declarations** (`intelligence.rs`, `extract.rs`, `legacy.rs`)

- Swift `protocol` declarations produce Interface structure and symbols, including nested requirements
- Swift `struct`, `actor` and `extension` keep their own kind instead of all reporting as Class
- Swift `typealias` and top-level `let` constants are emitted as symbols; function-local bindings are not
- TypeScript `namespace` is a Namespace and supplies the owner span for the aliases inside it
- JavaScript and TypeScript module-level `const` bindings are Constant symbols; named arrow bindings are Functions without a duplicate constant; destructuring patterns do not become symbol names

**Configuration data** (`data_extraction.rs`)

- YAML flow sequences and shorthand flow mappings keep their children, keys and spans; comments no longer shift array ordinals; structured keys are skipped rather than copied into a scalar path
- TOML dotted keys follow their segments instead of source spacing; a trailing comment no longer discards container children or replaces the span
- JSON property spans include the key before a multiline value; multiple roots are rejected instead of silently returning the first
- Terraform routes through the existing generic HCL adapter, and HCL block labels are key segments without their quotes

No grammar, query pack or DataNode schema changes.

## Validation

- `TSLP_LINK_MODE=static TSLP_LANGUAGES=swift,typescript,tsx,javascript cargo test -p tree-sitter-language-pack --test declaration_intelligence`
- `TSLP_LINK_MODE=static TSLP_LANGUAGES=yaml,toml,json,terraform,hcl cargo test -p tree-sitter-language-pack --test configuration_nodes`
- `cargo clippy -p tree-sitter-language-pack -- -D warnings`
- `cargo fmt --all -- --check`

Every new test failed before its fix and passes after, against the real parsers. Downstream, our macOS client builds against this branch and its full extraction suite passes, including the shared fixtures it checks against our server.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable (8 declaration tests, 11 configuration tests)

Thanks again,
Robert
