### PR TITLE
feat: restore Rust extension ambiguity lookup

### DIFF
--- a/.alef-generation.toml
+++ b/.alef-generation.toml
@@ -11,4 +11,4 @@
 # Do not hand-edit; it is rewritten by `alef generate`/`alef all` on every successful run.
 
 [crates]
-tree-sitter-language-pack = "d93bc82dba939e7073653dc369f0578e57275d825274cc0e035e46ffe2ebd1fa"
+tree-sitter-language-pack = "bdc031b7061c859a9a98c17fec150dff14afb87259c6075ee95206d4dfdda545"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Restore the Rust `extension_ambiguity()` API and its serde-gated JSON companion to expose the
+  default language and alternatives for ambiguous file extensions. (#185)
+
 ## [1.16.2] - 2026-09-05
 
 ### Fixed

--- a/crates/ts-pack-core/src/extensions.rs
+++ b/crates/ts-pack-core/src/extensions.rs
@@ -20,6 +20,57 @@ pub fn detect_language_from_extension(ext: &str) -> Option<&'static str> {
     include!(concat!(env!("OUT_DIR"), "/extensions_generated.rs"))
 }
 
+/// Return the assigned language and alternatives for an ambiguous file extension.
+///
+/// The extension must omit the leading dot. Matching is ASCII case-insensitive,
+/// like [`detect_language_from_extension`]. Returns `None` for unambiguous or
+/// unrecognized extensions. The assigned language matches extension detection;
+/// alternatives list other languages declared in the language definitions.
+/// This lookup does not require the corresponding parsers to be installed.
+///
+/// ```
+/// use tree_sitter_language_pack::extension_ambiguity;
+/// assert_eq!(extension_ambiguity("H"), Some(("c", &["cpp", "objc"][..])));
+/// assert_eq!(extension_ambiguity("m"), Some(("objc", &["matlab"][..])));
+/// assert_eq!(extension_ambiguity("py"), None);
+/// ```
+pub fn extension_ambiguity(ext: &str) -> Option<(&'static str, &'static [&'static str])> {
+    const MAX_EXTENSION_BYTES: usize = 32;
+    let mut buffer = [0u8; MAX_EXTENSION_BYTES];
+    if ext.len() > buffer.len() || !ext.is_ascii() {
+        return None;
+    }
+    for (index, byte) in ext.bytes().enumerate() {
+        buffer[index] = byte.to_ascii_lowercase();
+    }
+    let ext_lower = std::str::from_utf8(&buffer[..ext.len()]).ok()?;
+
+    include!(concat!(env!("OUT_DIR"), "/ambiguities_generated.rs"))
+}
+
+/// Serialize [`extension_ambiguity`] as JSON with `assigned` and `alternatives` fields.
+///
+/// Available with the `serde` feature. Returns `None` when the extension is
+/// unambiguous or unrecognized.
+///
+/// ```
+/// use tree_sitter_language_pack::extension_ambiguity_json;
+/// assert_eq!(
+///     extension_ambiguity_json("m"),
+///     Some(serde_json::json!({"assigned": "objc", "alternatives": ["matlab"]}).to_string())
+/// );
+/// ```
+#[cfg(feature = "serde")]
+pub fn extension_ambiguity_json(ext: &str) -> Option<String> {
+    extension_ambiguity(ext).map(|(assigned, alternatives)| {
+        serde_json::json!({
+            "assigned": assigned,
+            "alternatives": alternatives,
+        })
+        .to_string()
+    })
+}
+
 /// Detect language name from a file path.
 ///
 /// Extracts the file extension and looks it up. Returns `None` if the

--- a/crates/ts-pack-core/src/lib.rs
+++ b/crates/ts-pack-core/src/lib.rs
@@ -70,7 +70,11 @@ pub(crate) mod definitions;
 pub mod download;
 
 pub use error::Error;
-pub use extensions::{detect_language_from_content, detect_language_from_extension, detect_language_from_path};
+#[cfg(feature = "serde")]
+pub use extensions::extension_ambiguity_json;
+pub use extensions::{
+    detect_language_from_content, detect_language_from_extension, detect_language_from_path, extension_ambiguity,
+};
 pub use intel::types::{
     ChunkContext, CodeChunk, CommentInfo, CommentKind, DataAttribute, DataNode, DataNodeKind, Diagnostic,
     DiagnosticSeverity, DocSection, DocstringFormat, DocstringInfo, ExportInfo, ExportKind, FileMetrics, ImportInfo,

--- a/crates/ts-pack-core/tests/extension_ambiguity.rs
+++ b/crates/ts-pack-core/tests/extension_ambiguity.rs
@@ -1,0 +1,56 @@
+use tree_sitter_language_pack::{detect_language_from_extension, extension_ambiguity};
+
+#[test]
+fn should_return_assigned_language_and_all_alternatives_for_ambiguous_extensions() {
+    let cases: &[(&str, &str, &[&str])] = &[
+        ("h", "c", &["cpp", "objc"]),
+        ("gd", "gdscript", &["gap"]),
+        ("mod", "gomod", &["fortran"]),
+        ("conf", "nginx", &["hocon"]),
+        ("m", "objc", &["matlab"]),
+        ("pl", "perl", &["prolog"]),
+        ("sv", "systemverilog", &["verilog"]),
+        ("svh", "systemverilog", &["verilog"]),
+        ("v", "v", &["verilog"]),
+    ];
+
+    for &(extension, assigned, alternatives) in cases {
+        assert_eq!(
+            extension_ambiguity(extension),
+            Some((assigned, alternatives)),
+            "ambiguity for {extension}"
+        );
+        assert_eq!(detect_language_from_extension(extension), Some(assigned));
+    }
+}
+
+#[test]
+fn should_match_ambiguous_extensions_case_insensitively() {
+    for extension in ["conf", "CONF", "CoNf"] {
+        assert_eq!(extension_ambiguity(extension), Some(("nginx", &["hocon"][..])));
+    }
+}
+
+#[test]
+fn should_return_none_for_unambiguous_unknown_or_invalid_extensions() {
+    for extension in ["py", "rs", "xyz", "", ".m", "file.m", " m", "m ", "m\0", "м", "Ｍ"] {
+        assert_eq!(extension_ambiguity(extension), None, "input {extension:?}");
+    }
+    for length in [32, 33, 4096] {
+        assert_eq!(extension_ambiguity(&"m".repeat(length)), None);
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn should_serialize_assigned_language_and_alternatives_with_historical_field_names() {
+    use tree_sitter_language_pack::extension_ambiguity_json;
+
+    assert_eq!(
+        extension_ambiguity_json("H"),
+        Some(serde_json::json!({"assigned": "c", "alternatives": ["cpp", "objc"]}).to_string())
+    );
+    for extension in ["py", "xyz", "", ".h", "н"] {
+        assert_eq!(extension_ambiguity_json(extension), None, "input {extension:?}");
+    }
+}

--- a/docs-site/src/content/docs/guides/parsing.mdx
+++ b/docs-site/src/content/docs/guides/parsing.mdx
@@ -45,6 +45,25 @@ For batch processing in Rust, reuse the parser object. Creating one parser per p
 Names are case-sensitive — use the lowercase canonical form. Aliases exist: `shell` -> `bash`, `makefile` -> `make`, `bazel` -> `starlark`. See [Languages](/languages/) for the full list.
 :::
 
+## Ambiguous extensions in Rust
+
+`detect_language_from_extension()` returns the default language for an extension. Use
+`extension_ambiguity()` to check whether other languages share that extension before choosing a parser:
+
+```rust
+use tree_sitter_language_pack::extension_ambiguity;
+
+let (default_language, alternatives) = extension_ambiguity("h").expect("ambiguous extension");
+assert_eq!(default_language, "c");
+assert_eq!(alternatives, &["cpp", "objc"]);
+assert_eq!(extension_ambiguity("rs"), None);
+```
+
+Pass the extension without a leading dot. Matching ignores ASCII case, and unknown or unambiguous
+extensions return `None`. With the `serde` feature enabled, `extension_ambiguity_json()` returns the
+same information as a JSON object with `assigned` and `alternatives` fields. These lookups use the
+complete language registry and do not require downloaded parsers.
+
 ## The syntax tree
 
 Every parse returns a `Tree` with a single root node. Its kind is the top-level grammar node for the language: `module` for Python, `program` for JavaScript, `source_file` for Rust and Go.


### PR DESCRIPTION
Restore the Rust `extension_ambiguity()` API and its serde-gated JSON companion with their historical signatures and behavior. The lookup reuses the existing generated registry, preserves language-detection defaults, and works without installed parsers. Fixes #185.

Regression tests cover all nine ambiguous extensions, ASCII case handling, invalid inputs, and the JSON fields. Minimal/default/serde feature tests, both doctests, 30 existing extension tests, strict Clippy, and the full Poly lint run pass.

`alef verify --exit-code` passes (8,421 content-verified files, none missing), and Poly formatting is clean. Full regeneration separately reports pre-existing pnpm manifest/lock mismatches in `e2e/wasm` and `test_apps/node`; this PR does not change those dependencies.
