### PR TITLE
feat(intel): SQL, Justfile, Dockerfile, C, Cedar, dotenv and plist declarations

### DIFF
--- a/crates/ts-pack-core/src/intel/c.rs
+++ b/crates/ts-pack-core/src/intel/c.rs
@@ -102,34 +102,52 @@ pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
 
 /// The identifier at the bottom of a declarator chain, whatever pointers,
 /// arrays, parentheses and initialisers wrap it.
+///
+/// The chain is one grammar node per wrapper, so it is walked with an explicit
+/// stack rather than by recursion: a declarator behind 100,000 pointers is a
+/// valid parse, and a frame per pointer would overflow the 2 MiB stacks the
+/// library runs on. The search is depth first in source order, first match
+/// wins, which is the order the recursive form visited.
 fn innermost_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
-    match node.kind() {
-        "identifier" | "type_identifier" | "field_identifier" => Some(node),
-        _ => {
-            // ~keep A parenthesised declarator (`(*name)(int)`) holds its inner
-            // ~keep declarator as an unnamed child rather than a field.
-            if let Some(inner) = node.child_by_field_name("declarator") {
-                return innermost_identifier(inner);
+    let mut pending = vec![node];
+    while let Some(current) = pending.pop() {
+        match current.kind() {
+            "identifier" | "type_identifier" | "field_identifier" => return Some(current),
+            _ => {
+                // ~keep A parenthesised declarator (`(*name)(int)`) holds its inner
+                // ~keep declarator as an unnamed child rather than a field.
+                if let Some(inner) = current.child_by_field_name("declarator") {
+                    pending.push(inner);
+                    continue;
+                }
+                let mut cursor = current.walk();
+                let children: Vec<Node<'tree>> = current
+                    .named_children(&mut cursor)
+                    .filter(|child| child.kind().ends_with("declarator") || child.kind().ends_with("identifier"))
+                    .collect();
+                pending.extend(children.into_iter().rev());
             }
-            let mut cursor = node.walk();
-            let children: Vec<Node<'tree>> = node.named_children(&mut cursor).collect();
-            children
-                .into_iter()
-                .filter(|child| child.kind().ends_with("declarator") || child.kind().ends_with("identifier"))
-                .find_map(innermost_identifier)
         }
     }
+    None
 }
 
 /// The name a prototype declares: pointers may wrap the function declarator,
 /// but the declarator itself must apply to a bare identifier.
+///
+/// Iterative for the same reason as [`innermost_identifier`].
 fn prototype_name<'tree>(declarator: &Node<'tree>) -> Option<Node<'tree>> {
-    match declarator.kind() {
-        "pointer_declarator" => prototype_name(&declarator.child_by_field_name("declarator")?),
-        "function_declarator" => declarator
-            .child_by_field_name("declarator")
-            .filter(|inner| inner.kind() == "identifier"),
-        _ => None,
+    let mut current = *declarator;
+    loop {
+        match current.kind() {
+            "pointer_declarator" => current = current.child_by_field_name("declarator")?,
+            "function_declarator" => {
+                return current
+                    .child_by_field_name("declarator")
+                    .filter(|inner| inner.kind() == "identifier");
+            }
+            _ => return None,
+        }
     }
 }
 

--- a/crates/ts-pack-core/src/intel/c.rs
+++ b/crates/ts-pack-core/src/intel/c.rs
@@ -2,11 +2,18 @@
 //!
 //! The C grammar names a definition and a prototype differently: a
 //! `function_definition` has a body, while a prototype is a `declaration`
-//! whose declarator is a `function_declarator` applied directly to an
-//! identifier. Both are functions here, because a header's prototypes are the
-//! declarations a reader of that header is looking for. A declaration whose
-//! function declarator wraps a parenthesised pointer (`int (*f)(int);`) is a
-//! function pointer variable, and variables declare nothing here.
+//! whose declarator is a `function_declarator`. Both are functions here,
+//! because a header's prototypes are the declarations a reader of that header
+//! is looking for.
+//!
+//! A prototype is not written only one way, so the declarator is followed
+//! rather than matched: `int plain(int);` names its function directly,
+//! `int (foo)(int);` wraps the name in redundant parentheses, and
+//! `int (*factory(void))(int);` returns a function pointer and names its
+//! function under an inner declarator. What separates those from
+//! `int (*variable)(int);`, which is a function pointer VARIABLE and declares
+//! no function, is whether a function declarator applies to the name. See
+//! [`prototype_name`], which carries the measured shapes.
 //!
 //! A `struct`, `union` or `enum` is an item only where it is defined, which
 //! the grammar marks with a `body`, and only where it has a name: a nameless
@@ -24,7 +31,7 @@
 
 use tree_sitter::Node;
 
-use super::intelligence::{node_text, span_between, span_trimmed};
+use super::intelligence::{node_text, span_between_from};
 use super::types::*;
 use super::walk::{Descend, walk_bounded, warn_if_truncated};
 
@@ -132,23 +139,81 @@ fn innermost_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
     None
 }
 
-/// The name a prototype declares: pointers may wrap the function declarator,
-/// but the declarator itself must apply to a bare identifier.
+/// The name a prototype declares, or `None` where the declaration declares a
+/// variable instead.
+///
+/// C spells a function declaration more than one way, and the grammar mirrors
+/// each. Measured against the real parser:
+///
+/// - `int plain(int);` is `function_declarator > identifier`.
+/// - `int (foo)(int);` wraps the name in parentheses, which are redundant but
+///   legal: `function_declarator > parenthesized_declarator > identifier`.
+/// - `int (*factory(void))(int);` is a function returning a function pointer:
+///   the OUTER `function_declarator` belongs to the returned pointer, and the
+///   name sits under an inner one,
+///   `function_declarator > parenthesized_declarator > pointer_declarator >
+///   function_declarator > identifier`.
+/// - `int (*variable)(int);` is a function POINTER VARIABLE and declares no
+///   function: `function_declarator > parenthesized_declarator >
+///   pointer_declarator > identifier`.
+///
+/// The last two differ only in what sits below the pointer, so the rule is
+/// what a pointer is crossed *to*: reaching an identifier through a pointer
+/// with no function declarator in between is a variable, while an inner
+/// function declarator is a function and names it. Requiring an immediate
+/// identifier, as this did before, dropped the middle two.
 ///
 /// Iterative for the same reason as [`innermost_identifier`].
 fn prototype_name<'tree>(declarator: &Node<'tree>) -> Option<Node<'tree>> {
     let mut current = *declarator;
     loop {
         match current.kind() {
-            "pointer_declarator" => current = current.child_by_field_name("declarator")?,
-            "function_declarator" => {
-                return current
+            // ~keep A pointer between here and the name belongs to a
+            // ~keep variable: `int (*variable)(int);` is a function pointer,
+            // ~keep and the function declarator above it describes the type
+            // ~keep pointed at, not something this file declares. The name is
+            // ~keep only reachable through an inner function declarator, so
+            // ~keep descend and let that arm decide.
+            "pointer_declarator" | "parenthesized_declarator" => {
+                current = current
                     .child_by_field_name("declarator")
-                    .filter(|inner| inner.kind() == "identifier");
+                    .or_else(|| sole_declarator(&current))?;
+            }
+            "function_declarator" => {
+                let inner = current.child_by_field_name("declarator")?;
+                // ~keep The declarator this function applies to. A bare
+                // ~keep identifier, or one wrapped only in parentheses, is
+                // ~keep the function's own name.
+                match inner.kind() {
+                    "identifier" => return Some(inner),
+                    "parenthesized_declarator" => {
+                        let sole = sole_declarator(&inner)?;
+                        if sole.kind() == "identifier" {
+                            return Some(sole);
+                        }
+                        // ~keep A further declarator, so the name below it is
+                        // ~keep named by ITS function declarator if it has
+                        // ~keep one: `int (*factory(void))(int);` returns a
+                        // ~keep function pointer and declares `factory`.
+                        // ~keep Looping rather than recursing, because a
+                        // ~keep declarator chain is as deep as the source
+                        // ~keep makes it.
+                        current = sole;
+                    }
+                    _ => current = inner,
+                }
             }
             _ => return None,
         }
     }
+}
+
+/// The declarator inside a `parenthesized_declarator`, which the grammar
+/// holds as an unnamed child rather than in the `declarator` field.
+fn sole_declarator<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| child.kind().ends_with("declarator") || child.kind() == "identifier")
 }
 
 /// A named aggregate defined in the `type` field of a typedef or declaration.
@@ -177,11 +242,8 @@ fn aggregate(node: &Node<'_>, source: &str) -> Option<StructureItem> {
 }
 
 fn item(kind: StructureKind, name: &Node<'_>, node: &Node<'_>, end: usize, source: &str) -> StructureItem {
-    let span = if end == node.end_byte() {
-        span_trimmed(node, source)
-    } else {
-        span_between(source, node.start_byte(), end)
-    };
+    let start = node.start_position();
+    let span = span_between_from(source, node.start_byte(), end, (start.row, start.column));
     StructureItem {
         kind,
         name: Some(node_text(name, source).to_string()),

--- a/crates/ts-pack-core/src/intel/c.rs
+++ b/crates/ts-pack-core/src/intel/c.rs
@@ -1,0 +1,173 @@
+//! C declaration extraction, for sources and headers.
+//!
+//! The C grammar names a definition and a prototype differently: a
+//! `function_definition` has a body, while a prototype is a `declaration`
+//! whose declarator is a `function_declarator` applied directly to an
+//! identifier. Both are functions here, because a header's prototypes are the
+//! declarations a reader of that header is looking for. A declaration whose
+//! function declarator wraps a parenthesised pointer (`int (*f)(int);`) is a
+//! function pointer variable, and variables declare nothing here.
+//!
+//! A `struct`, `union` or `enum` is an item only where it is defined, which
+//! the grammar marks with a `body`, and only where it has a name: a nameless
+//! `typedef struct { ... } name_t;` is the typedef alone. A definition that
+//! sits inside a `typedef` or a variable declaration is read out of the
+//! `type` field, so `typedef struct node { ... } node_t;` is two items with
+//! two names. Typedefs are `Other("Type")`. An object-like macro is
+//! `Other("Constant")` and a function-like one `Other("Macro")`; macro bodies
+//! never reach an item. Fields, enumerators, includes and anything inside a
+//! function body produce nothing. Preprocessor conditionals and `extern "C"`
+//! blocks are transparent, so a header guarded by `#ifndef` reads as its
+//! contents.
+//!
+//! Entry point: [`structure`].
+
+use tree_sitter::Node;
+
+use super::intelligence::{node_text, span_between, span_trimmed};
+use super::types::*;
+use super::walk::{Descend, walk_bounded, warn_if_truncated};
+
+/// Every function, prototype, named aggregate, typedef and macro in `root`,
+/// in source order.
+pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut items = Vec::new();
+    let truncated = walk_bounded(root, |node, _depth| {
+        match node.kind() {
+            "translation_unit"
+            | "preproc_ifdef"
+            | "preproc_if"
+            | "preproc_elif"
+            | "preproc_elifdef"
+            | "preproc_else"
+            | "linkage_specification"
+            | "declaration_list"
+            | "ERROR" => return Descend::Children,
+            "function_definition" => {
+                if let Some(name) = node.child_by_field_name("declarator").and_then(innermost_identifier) {
+                    items.push(item(StructureKind::Function, &name, node, node.end_byte(), source));
+                }
+            }
+            "declaration" => {
+                let mut cursor = node.walk();
+                for declarator in node.children_by_field_name("declarator", &mut cursor) {
+                    if let Some(name) = prototype_name(&declarator) {
+                        items.push(item(StructureKind::Function, &name, node, node.end_byte(), source));
+                    }
+                }
+                items.extend(defined_aggregate(node, source));
+            }
+            "type_definition" => {
+                let mut cursor = node.walk();
+                for declarator in node.children_by_field_name("declarator", &mut cursor) {
+                    if let Some(name) = innermost_identifier(declarator) {
+                        items.push(item(
+                            StructureKind::Other("Type".to_string()),
+                            &name,
+                            node,
+                            node.end_byte(),
+                            source,
+                        ));
+                    }
+                }
+                items.extend(defined_aggregate(node, source));
+            }
+            "struct_specifier" | "union_specifier" | "enum_specifier" => {
+                items.extend(aggregate(node, source));
+            }
+            "preproc_def" | "preproc_function_def" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    let label = if node.kind() == "preproc_def" {
+                        "Constant"
+                    } else {
+                        "Macro"
+                    };
+                    items.push(item(
+                        StructureKind::Other(label.to_string()),
+                        &name,
+                        node,
+                        node.end_byte(),
+                        source,
+                    ));
+                }
+            }
+            _ => {}
+        }
+        Descend::Skip
+    });
+    warn_if_truncated(truncated, "intel::c", "c");
+    items.sort_by_key(|item| item.span.start_byte);
+    items
+}
+
+/// The identifier at the bottom of a declarator chain, whatever pointers,
+/// arrays, parentheses and initialisers wrap it.
+fn innermost_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    match node.kind() {
+        "identifier" | "type_identifier" | "field_identifier" => Some(node),
+        _ => {
+            // ~keep A parenthesised declarator (`(*name)(int)`) holds its inner
+            // ~keep declarator as an unnamed child rather than a field.
+            if let Some(inner) = node.child_by_field_name("declarator") {
+                return innermost_identifier(inner);
+            }
+            let mut cursor = node.walk();
+            let children: Vec<Node<'tree>> = node.named_children(&mut cursor).collect();
+            children
+                .into_iter()
+                .filter(|child| child.kind().ends_with("declarator") || child.kind().ends_with("identifier"))
+                .find_map(innermost_identifier)
+        }
+    }
+}
+
+/// The name a prototype declares: pointers may wrap the function declarator,
+/// but the declarator itself must apply to a bare identifier.
+fn prototype_name<'tree>(declarator: &Node<'tree>) -> Option<Node<'tree>> {
+    match declarator.kind() {
+        "pointer_declarator" => prototype_name(&declarator.child_by_field_name("declarator")?),
+        "function_declarator" => declarator
+            .child_by_field_name("declarator")
+            .filter(|inner| inner.kind() == "identifier"),
+        _ => None,
+    }
+}
+
+/// A named aggregate defined in the `type` field of a typedef or declaration.
+fn defined_aggregate(node: &Node<'_>, source: &str) -> Option<StructureItem> {
+    let specifier = node.child_by_field_name("type")?;
+    aggregate(&specifier, source)
+}
+
+/// A `struct`, `union` or `enum` specifier that both names and defines its
+/// type. A top-level specifier's terminator is its sibling, and the item
+/// runs through it.
+fn aggregate(node: &Node<'_>, source: &str) -> Option<StructureItem> {
+    let kind = match node.kind() {
+        "struct_specifier" => StructureKind::Struct,
+        "union_specifier" => StructureKind::Other("Union".to_string()),
+        "enum_specifier" => StructureKind::Enum,
+        _ => return None,
+    };
+    let name = node.child_by_field_name("name")?;
+    node.child_by_field_name("body")?;
+    let end = node
+        .next_sibling()
+        .filter(|sibling| sibling.kind() == ";")
+        .map_or(node.end_byte(), |terminator| terminator.end_byte());
+    Some(item(kind, &name, node, end, source))
+}
+
+fn item(kind: StructureKind, name: &Node<'_>, node: &Node<'_>, end: usize, source: &str) -> StructureItem {
+    let span = if end == node.end_byte() {
+        span_trimmed(node, source)
+    } else {
+        span_between(source, node.start_byte(), end)
+    };
+    StructureItem {
+        kind,
+        name: Some(node_text(name, source).to_string()),
+        span,
+        ..StructureItem::default()
+    }
+}

--- a/crates/ts-pack-core/src/intel/cedar.rs
+++ b/crates/ts-pack-core/src/intel/cedar.rs
@@ -1,0 +1,60 @@
+//! Cedar policy extraction.
+//!
+//! A policy set is a flat list of `permit` and `forbid` policies, and Cedar
+//! itself identifies a policy by its `@id("...")` annotation, so that is the
+//! name here. A policy without an `@id` has no name Cedar would report it by
+//! and produces nothing; two policies carrying the same `@id` are two items,
+//! told apart by their spans. Templates (`?principal`, `?resource`) are
+//! policies to the grammar and are read the same way. Comments, including one
+//! that spells `@id(...)` in prose, are never policies.
+//!
+//! The span is the policy node: its annotations through its terminator. The
+//! effect, scope and conditions never reach an item.
+//!
+//! Entry point: [`structure`].
+
+use tree_sitter::Node;
+
+use super::intelligence::{node_text, span_trimmed};
+use super::types::*;
+use super::walk::{Descend, walk_bounded, warn_if_truncated};
+
+/// Every policy in `root` that carries an `@id`, in source order.
+pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut items = Vec::new();
+    let truncated = walk_bounded(root, |node, _depth| {
+        if node.kind() != "policy" {
+            return Descend::Children;
+        }
+        if let Some(id) = policy_id(node, source) {
+            items.push(StructureItem {
+                kind: StructureKind::Other("Policy".to_string()),
+                name: Some(id),
+                span: span_trimmed(node, source),
+                ..StructureItem::default()
+            });
+        }
+        Descend::Skip
+    });
+    warn_if_truncated(truncated, "intel::cedar", "cedar");
+    items
+}
+
+/// The content of the first `@id("...")` annotation on `policy`, as written.
+fn policy_id(policy: &Node<'_>, source: &str) -> Option<String> {
+    let mut cursor = policy.walk();
+    policy
+        .named_children(&mut cursor)
+        .filter(|child| child.kind() == "annotation")
+        .find_map(|annotation| {
+            let mut inner = annotation.walk();
+            let mut parts = annotation.named_children(&mut inner);
+            parts.next().filter(|key| node_text(key, source) == "id")?;
+            let string = parts.next().filter(|value| value.kind() == "string")?;
+            let mut chars = string.walk();
+            string
+                .named_children(&mut chars)
+                .find(|part| part.kind() == "string_content")
+                .map(|content| node_text(&content, source).to_string())
+        })
+}

--- a/crates/ts-pack-core/src/intel/data_extraction.rs
+++ b/crates/ts-pack-core/src/intel/data_extraction.rs
@@ -1214,17 +1214,13 @@ fn xml_element_node(node: &Node, source: &str, depth: usize, truncated: &mut usi
         })
         .unwrap_or_default();
 
-    let text_value = named
-        .iter()
-        .find(|c| c.kind() == "content")
-        .and_then(|content| {
-            let mut c2 = content.walk();
-            content
-                .named_children(&mut c2)
-                .find(|gc| gc.kind() == "CharData" || gc.kind() == "CData")
-                .map(|n| node_text(&n, source).trim().to_string())
-        })
-        .filter(|s| !s.is_empty());
+    // ~keep The whole text run, not its first node: an entity reference or a
+    // ~keep CDATA section splits it. Trimmed here, unlike a property list
+    // ~keep scalar, because an element holding only layout whitespace between
+    // ~keep its children carries no value.
+    let text_value = xml_text(node, source)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty());
 
     let children: Vec<DataNode> = named
         .iter()
@@ -1287,7 +1283,12 @@ fn plist_value_node(
         "dict" => (None, plist_dict_children(node, source, depth + 1, truncated)),
         "array" => (None, plist_array_children(node, source, depth + 1, truncated)),
         "true" | "false" => (Some(tag.clone()), vec![]),
-        _ => (Some(xml_text(node, source).unwrap_or_default()), vec![]),
+        // ~keep A `<string>` carries its whitespace: " padded " is that value,
+        // ~keep not "padded". The other scalars are a number or a date, which
+        // ~keep an XML writer is free to indent onto its own line, so those
+        // ~keep trim.
+        "string" => (Some(xml_text(node, source).unwrap_or_default()), vec![]),
+        _ => (Some(plist_trimmed_text(node, source)), vec![]),
     };
     DataNode {
         kind,
@@ -1297,6 +1298,13 @@ fn plist_value_node(
         children,
         span: span_from_node(node),
     }
+}
+
+/// An element's text with surrounding layout whitespace removed, for the
+/// plist parts that name rather than carry a value: a `<key>`, and the
+/// scalars an XML writer may indent onto their own line.
+fn plist_trimmed_text(node: &Node, source: &str) -> String {
+    xml_text(node, source).map_or_else(String::new, |text| text.trim().to_string())
 }
 
 fn plist_dict_children(node: &Node, source: &str, depth: usize, truncated: &mut usize) -> Vec<DataNode> {
@@ -1315,7 +1323,7 @@ fn plist_dict_children(node: &Node, source: &str, depth: usize, truncated: &mut 
         let value = &elements[index + 1];
         let mut entry = plist_value_node(
             value,
-            Some(xml_text(key, source).unwrap_or_default()),
+            Some(plist_trimmed_text(key, source)),
             DataNodeKind::KeyValue,
             source,
             depth,
@@ -1372,13 +1380,69 @@ fn xml_tag_name(node: &Node, source: &str) -> Option<String> {
         .map(|name| node_text(&name, source).to_string())
 }
 
+/// The complete text of an element, in source order.
+///
+/// A text run is not one node. An entity reference (`&amp;`), a character
+/// reference (`&#65;`) and a CDATA section each interrupt it, so `a&amp;b`
+/// arrives as `CharData EntityRef CharData` and reading the first child alone
+/// truncates the value at the first `&`. CDATA is a `CData` beneath a
+/// `CDSect`, never a direct child of `content`, so a direct-child search for
+/// it finds nothing and the value reads empty.
+///
+/// The text is returned as written, untrimmed: whitespace is significant in a
+/// property list `<string>`, and the caller decides whether it matters.
 fn xml_text(node: &Node, source: &str) -> Option<String> {
     let content = named_child_of_kind(node, "content")?;
     let mut cursor = content.walk();
-    content
-        .named_children(&mut cursor)
-        .find(|gc| gc.kind() == "CharData" || gc.kind() == "CData")
-        .map(|n| node_text(&n, source).trim().to_string())
+    let mut text = String::new();
+    for part in content.named_children(&mut cursor) {
+        append_xml_text(&part, source, &mut text);
+    }
+    Some(text)
+}
+
+/// Append one `content` child's contribution to `text`. Nested one level for
+/// `CDSect`, which is as deep as the grammar puts character data; nothing
+/// here recurses on tree depth.
+fn append_xml_text(part: &Node, source: &str, text: &mut String) {
+    match part.kind() {
+        "CharData" | "CData" => text.push_str(node_text(part, source)),
+        "EntityRef" | "CharRef" => text.push_str(&resolve_xml_reference(node_text(part, source))),
+        "CDSect" => {
+            let mut cursor = part.walk();
+            for inner in part.named_children(&mut cursor) {
+                if inner.kind() == "CData" {
+                    text.push_str(node_text(&inner, source));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The character an XML reference stands for.
+///
+/// The five predefined entities and numeric character references resolve. Any
+/// other entity is declared in a DTD this reader does not read, so it is kept
+/// as written rather than dropped, which would silently lose text.
+fn resolve_xml_reference(reference: &str) -> String {
+    match reference {
+        "&amp;" => return "&".to_string(),
+        "&lt;" => return "<".to_string(),
+        "&gt;" => return ">".to_string(),
+        "&quot;" => return "\"".to_string(),
+        "&apos;" => return "'".to_string(),
+        _ => {}
+    }
+    reference
+        .strip_prefix("&#")
+        .and_then(|rest| rest.strip_suffix(';'))
+        .and_then(|digits| match digits.strip_prefix(['x', 'X']) {
+            Some(hex) => u32::from_str_radix(hex, 16).ok(),
+            None => digits.parse::<u32>().ok(),
+        })
+        .and_then(char::from_u32)
+        .map_or_else(|| reference.to_string(), String::from)
 }
 
 /// A dotenv file is a flat list of `KEY=value` lines, so every assignment is

--- a/crates/ts-pack-core/src/intel/data_extraction.rs
+++ b/crates/ts-pack-core/src/intel/data_extraction.rs
@@ -67,6 +67,7 @@ pub(crate) fn extract_data(root: &Node, source: &str, language: &str) -> Option<
         "caddy" => extract_caddy(root, source, truncated),
         "xml" => extract_xml(root, source, truncated),
         "dtd" => extract_dtd(root, source),
+        "dotenv" => extract_dotenv(root, source),
         _ => None,
     };
     warn_if_truncated(*truncated, "intel::data_extraction", language);
@@ -1158,6 +1159,9 @@ fn caddy_directive_node(node: &Node, source: &str) -> Option<DataNode> {
 }
 
 fn extract_xml(root: &Node, source: &str, truncated: &mut usize) -> Option<DataNode> {
+    if let Some(top) = plist_top_value(root, source) {
+        return Some(extract_plist(root, &top, source, truncated));
+    }
     let children = xml_node_children(root, source, 0, truncated);
     Some(DataNode {
         kind: DataNodeKind::Element,
@@ -1235,6 +1239,179 @@ fn xml_element_node(node: &Node, source: &str, depth: usize, truncated: &mut usi
         attributes,
         children,
         span: span_from_node(node),
+    })
+}
+
+/// The single value element inside a `<plist>` root, when the document is a
+/// property list. Decided by the root tag, not the file name: a plist is XML
+/// whose meaning lives in its `<key>` text rather than its tag names, so it
+/// is read as keys and values wherever it appears.
+fn plist_top_value<'a>(root: &Node<'a>, source: &str) -> Option<Node<'a>> {
+    let element = root.child_by_field_name("root")?;
+    if xml_tag_name(&element, source)? != "plist" {
+        return None;
+    }
+    let content = named_child_of_kind(&element, "content")?;
+    named_child_of_kind(&content, "element")
+}
+
+/// A property list as keys and values. A `dict` entry is keyed by the text
+/// of its `<key>` element and spans from that key through its value; an
+/// `array` item is keyed by its position. The containers themselves add no
+/// segment, so a dict at the top reads like a JSON object and an array at
+/// the top like a JSON array. `<string>`, `<integer>`, `<real>`, `<date>`
+/// and `<data>` carry their text as the value; `<true/>` and `<false/>`
+/// carry their tag.
+fn extract_plist(root: &Node, top: &Node, source: &str, truncated: &mut usize) -> DataNode {
+    let value = plist_value_node(top, None, DataNodeKind::KeyValue, source, 0, truncated);
+    DataNode {
+        kind: DataNodeKind::KeyValue,
+        key: None,
+        value: value.value,
+        attributes: vec![],
+        children: value.children,
+        span: span_from_node(root),
+    }
+}
+
+fn plist_value_node(
+    node: &Node,
+    key: Option<String>,
+    kind: DataNodeKind,
+    source: &str,
+    depth: usize,
+    truncated: &mut usize,
+) -> DataNode {
+    let tag = xml_tag_name(node, source).unwrap_or_default();
+    let (value, children) = match tag.as_str() {
+        "dict" => (None, plist_dict_children(node, source, depth + 1, truncated)),
+        "array" => (None, plist_array_children(node, source, depth + 1, truncated)),
+        "true" | "false" => (Some(tag.clone()), vec![]),
+        _ => (Some(xml_text(node, source).unwrap_or_default()), vec![]),
+    };
+    DataNode {
+        kind,
+        key,
+        value,
+        attributes: vec![],
+        children,
+        span: span_from_node(node),
+    }
+}
+
+fn plist_dict_children(node: &Node, source: &str, depth: usize, truncated: &mut usize) -> Vec<DataNode> {
+    let mut result = Vec::new();
+    if depth_exceeded(node, depth, truncated) {
+        return result;
+    }
+    let elements = plist_elements(node);
+    let mut index = 0;
+    while index + 1 < elements.len() {
+        let key = &elements[index];
+        if xml_tag_name(key, source).as_deref() != Some("key") {
+            index += 1;
+            continue;
+        }
+        let value = &elements[index + 1];
+        let mut entry = plist_value_node(
+            value,
+            Some(xml_text(key, source).unwrap_or_default()),
+            DataNodeKind::KeyValue,
+            source,
+            depth,
+            truncated,
+        );
+        let start = key.start_position();
+        entry.span.start_byte = key.start_byte();
+        entry.span.start_line = start.row;
+        entry.span.start_column = start.column;
+        result.push(entry);
+        index += 2;
+    }
+    result
+}
+
+fn plist_array_children(node: &Node, source: &str, depth: usize, truncated: &mut usize) -> Vec<DataNode> {
+    if depth_exceeded(node, depth, truncated) {
+        return Vec::new();
+    }
+    plist_elements(node)
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            plist_value_node(
+                item,
+                Some(index.to_string()),
+                DataNodeKind::Sequence,
+                source,
+                depth,
+                truncated,
+            )
+        })
+        .collect()
+}
+
+/// The element children of an element's content, in order.
+fn plist_elements<'a>(node: &Node<'a>) -> Vec<Node<'a>> {
+    named_child_of_kind(node, "content")
+        .map(|content| {
+            let mut cursor = content.walk();
+            content
+                .named_children(&mut cursor)
+                .filter(|c| c.kind() == "element")
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn xml_tag_name(node: &Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|c| c.kind() == "STag" || c.kind() == "EmptyElemTag")
+        .and_then(|stag| named_child_of_kind(&stag, "Name"))
+        .map(|name| node_text(&name, source).to_string())
+}
+
+fn xml_text(node: &Node, source: &str) -> Option<String> {
+    let content = named_child_of_kind(node, "content")?;
+    let mut cursor = content.walk();
+    content
+        .named_children(&mut cursor)
+        .find(|gc| gc.kind() == "CharData" || gc.kind() == "CData")
+        .map(|n| node_text(&n, source).trim().to_string())
+}
+
+/// A dotenv file is a flat list of `KEY=value` lines, so every assignment is
+/// a keyed scalar and nothing nests. The value is carried as written, quotes
+/// and placeholders included; an assignment with nothing after `=` carries
+/// an empty value rather than none, so it still reads as a scalar.
+fn extract_dotenv(root: &Node, source: &str) -> Option<DataNode> {
+    let mut children = Vec::new();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.kind() == "assignment"
+            && let Some(key) = child.child_by_field_name("key")
+        {
+            let value = child
+                .child_by_field_name("value")
+                .map_or_else(String::new, |value| node_text(&value, source).to_string());
+            children.push(DataNode {
+                kind: DataNodeKind::KeyValue,
+                key: Some(node_text(&key, source).to_string()),
+                value: Some(value),
+                attributes: vec![],
+                children: vec![],
+                span: span_from_node(&child),
+            });
+        }
+    }
+    Some(DataNode {
+        kind: DataNodeKind::KeyValue,
+        key: None,
+        value: None,
+        attributes: vec![],
+        children,
+        span: span_from_node(root),
     })
 }
 

--- a/crates/ts-pack-core/src/intel/dockerfile.rs
+++ b/crates/ts-pack-core/src/intel/dockerfile.rs
@@ -1,0 +1,108 @@
+//! Dockerfile declaration extraction.
+//!
+//! A Dockerfile is a flat list of instructions, but a build stage is a real
+//! scope: it begins at `FROM ... AS name` and runs to the instruction before
+//! the next `FROM`. A named stage is a module whose span covers that run, and
+//! the `ARG` and `ENV` names declared inside it nest under it, so `ARG MIX_ENV`
+//! repeated in four stages of one file keeps four identities. Instructions
+//! before the first `FROM`, or under an unnamed `FROM`, are top-level items.
+//!
+//! `ARG` and every `ENV` pair are constants named by the variable and spanning
+//! the whole instruction. Values never reach an item. No other instruction
+//! declares a name, so `RUN`, `COPY` and the rest produce nothing.
+//!
+//! Entry point: [`structure`].
+
+use tree_sitter::Node;
+
+use super::intelligence::node_text;
+use super::types::*;
+use super::walk::{Descend, walk_bounded, warn_if_truncated};
+
+/// Every named stage, argument and environment variable in `root`, in source
+/// order, with a stage's declarations nested under it.
+pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut items = Vec::new();
+    let mut stage: Option<Stage> = None;
+    let truncated = walk_bounded(root, |node, _depth| {
+        match node.kind() {
+            "from_instruction" => {
+                close(&mut stage, &mut items, source);
+                stage = node.child_by_field_name("as").map(|alias| Stage {
+                    name: node_text(&alias, source).to_string(),
+                    start: node.start_byte(),
+                    end: node.end_byte(),
+                    children: Vec::new(),
+                });
+            }
+            "arg_instruction" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    push(&mut stage, &mut items, constant(&name, node, source));
+                }
+                extend(&mut stage, node);
+            }
+            "env_instruction" => {
+                let mut cursor = node.walk();
+                for pair in node
+                    .named_children(&mut cursor)
+                    .filter(|child| child.kind() == "env_pair")
+                {
+                    if let Some(name) = pair.child_by_field_name("name") {
+                        push(&mut stage, &mut items, constant(&name, node, source));
+                    }
+                }
+                extend(&mut stage, node);
+            }
+            // ~keep Error recovery and the root are transparent; a stage may sit inside either.
+            "source_file" | "ERROR" => return Descend::Children,
+            "comment" => {}
+            kind if kind.ends_with("_instruction") => extend(&mut stage, node),
+            _ => {}
+        }
+        Descend::Skip
+    });
+    warn_if_truncated(truncated, "intel::dockerfile", "dockerfile");
+    close(&mut stage, &mut items, source);
+    items
+}
+
+struct Stage {
+    name: String,
+    start: usize,
+    end: usize,
+    children: Vec<StructureItem>,
+}
+
+fn constant(name: &Node<'_>, instruction: &Node<'_>, source: &str) -> StructureItem {
+    StructureItem {
+        kind: StructureKind::Other("Constant".to_string()),
+        name: Some(node_text(name, source).to_string()),
+        span: super::intelligence::span_trimmed(instruction, source),
+        ..StructureItem::default()
+    }
+}
+
+fn push(stage: &mut Option<Stage>, items: &mut Vec<StructureItem>, item: StructureItem) {
+    match stage {
+        Some(stage) => stage.children.push(item),
+        None => items.push(item),
+    }
+}
+
+fn extend(stage: &mut Option<Stage>, instruction: &Node<'_>) {
+    if let Some(stage) = stage {
+        stage.end = stage.end.max(instruction.end_byte());
+    }
+}
+
+fn close(stage: &mut Option<Stage>, items: &mut Vec<StructureItem>, source: &str) {
+    if let Some(stage) = stage.take() {
+        items.push(StructureItem {
+            kind: StructureKind::Module,
+            name: Some(stage.name),
+            span: super::intelligence::span_between(source, stage.start, stage.end),
+            children: stage.children,
+            ..StructureItem::default()
+        });
+    }
+}

--- a/crates/ts-pack-core/src/intel/dockerfile.rs
+++ b/crates/ts-pack-core/src/intel/dockerfile.rs
@@ -28,11 +28,15 @@ pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
         match node.kind() {
             "from_instruction" => {
                 close(&mut stage, &mut items, source);
-                stage = node.child_by_field_name("as").map(|alias| Stage {
-                    name: node_text(&alias, source).to_string(),
-                    start: node.start_byte(),
-                    end: node.end_byte(),
-                    children: Vec::new(),
+                stage = node.child_by_field_name("as").map(|alias| {
+                    let start = node.start_position();
+                    Stage {
+                        name: node_text(&alias, source).to_string(),
+                        start: node.start_byte(),
+                        start_position: (start.row, start.column),
+                        end: node.end_byte(),
+                        children: Vec::new(),
+                    }
                 });
             }
             "arg_instruction" => {
@@ -69,6 +73,9 @@ pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
 struct Stage {
     name: String,
     start: usize,
+    /// The row and column of `start`, carried from the `FROM` node so closing
+    /// the stage does not recount the newlines above it.
+    start_position: (usize, usize),
     end: usize,
     children: Vec<StructureItem>,
 }
@@ -100,7 +107,7 @@ fn close(stage: &mut Option<Stage>, items: &mut Vec<StructureItem>, source: &str
         items.push(StructureItem {
             kind: StructureKind::Module,
             name: Some(stage.name),
-            span: super::intelligence::span_between(source, stage.start, stage.end),
+            span: super::intelligence::span_between_from(source, stage.start, stage.end, stage.start_position),
             children: stage.children,
             ..StructureItem::default()
         });

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -69,11 +69,12 @@ impl Wanted {
 /// [`super::walk::MAX_TREE_DEPTH`] the results are truncated and a WARN is
 /// emitted; no error is returned.
 pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted: Wanted, out: &mut ProcessResult) {
-    // ~keep SQL declarations are read by their own adapter (`super::sql`): the
-    // ~keep grammar shares node names with the generic arms while meaning
-    // ~keep something else (a plpgsql DECLARE variable is a `function_declaration`),
-    // ~keep so the language-neutral structure and symbol matchers must not see it.
-    let declarative = language == "sql";
+    // ~keep SQL and Just declarations are read by their own adapters (`super::sql`,
+    // ~keep `super::just`): their grammars share node names with the generic arms
+    // ~keep while meaning something else (a plpgsql DECLARE variable is a
+    // ~keep `function_declaration`), so the language-neutral structure and symbol
+    // ~keep matchers must not see them.
+    let declarative = matches!(language, "sql" | "just");
     let generic = Wanted {
         structure: wanted.structure && !declarative,
         symbols: wanted.symbols && !declarative,
@@ -84,7 +85,10 @@ pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted:
     warn_if_truncated(truncated, "intel::extract", language);
     collector.finish(out);
     if wanted.structure && declarative {
-        out.structure = super::sql::structure(root, source);
+        out.structure = match language {
+            "sql" => super::sql::structure(root, source),
+            _ => super::just::structure(root, source),
+        };
     }
     // ~keep Counts are reported once here, after the walk: a per-node event would
     // ~keep reintroduce the per-node cost this single-pass design exists to remove.

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -69,12 +69,13 @@ impl Wanted {
 /// [`super::walk::MAX_TREE_DEPTH`] the results are truncated and a WARN is
 /// emitted; no error is returned.
 pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted: Wanted, out: &mut ProcessResult) {
-    // ~keep SQL, Just and Dockerfile declarations are read by their own adapters
-    // ~keep (`super::sql`, `super::just`, `super::dockerfile`): their grammars
-    // ~keep share node names with the generic arms while meaning something else
-    // ~keep (a plpgsql DECLARE variable is a `function_declaration`), so the
+    // ~keep SQL, Just, Dockerfile and C declarations are read by their own
+    // ~keep adapters (`super::sql`, `super::just`, `super::dockerfile`, `super::c`):
+    // ~keep their grammars share node names with the generic arms while meaning
+    // ~keep something else (a plpgsql DECLARE variable is a `function_declaration`;
+    // ~keep a C prototype is a `declaration` the generic arms never see), so the
     // ~keep language-neutral structure and symbol matchers must not see them.
-    let declarative = matches!(language, "sql" | "just" | "dockerfile");
+    let declarative = matches!(language, "sql" | "just" | "dockerfile" | "c");
     let generic = Wanted {
         structure: wanted.structure && !declarative,
         symbols: wanted.symbols && !declarative,
@@ -88,6 +89,7 @@ pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted:
         out.structure = match language {
             "sql" => super::sql::structure(root, source),
             "just" => super::just::structure(root, source),
+            "c" => super::c::structure(root, source),
             _ => super::dockerfile::structure(root, source),
         };
     }

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -69,12 +69,12 @@ impl Wanted {
 /// [`super::walk::MAX_TREE_DEPTH`] the results are truncated and a WARN is
 /// emitted; no error is returned.
 pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted: Wanted, out: &mut ProcessResult) {
-    // ~keep SQL and Just declarations are read by their own adapters (`super::sql`,
-    // ~keep `super::just`): their grammars share node names with the generic arms
-    // ~keep while meaning something else (a plpgsql DECLARE variable is a
-    // ~keep `function_declaration`), so the language-neutral structure and symbol
-    // ~keep matchers must not see them.
-    let declarative = matches!(language, "sql" | "just");
+    // ~keep SQL, Just and Dockerfile declarations are read by their own adapters
+    // ~keep (`super::sql`, `super::just`, `super::dockerfile`): their grammars
+    // ~keep share node names with the generic arms while meaning something else
+    // ~keep (a plpgsql DECLARE variable is a `function_declaration`), so the
+    // ~keep language-neutral structure and symbol matchers must not see them.
+    let declarative = matches!(language, "sql" | "just" | "dockerfile");
     let generic = Wanted {
         structure: wanted.structure && !declarative,
         symbols: wanted.symbols && !declarative,
@@ -87,7 +87,8 @@ pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted:
     if wanted.structure && declarative {
         out.structure = match language {
             "sql" => super::sql::structure(root, source),
-            _ => super::just::structure(root, source),
+            "just" => super::just::structure(root, source),
+            _ => super::dockerfile::structure(root, source),
         };
     }
     // ~keep Counts are reported once here, after the walk: a per-node event would

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -69,10 +69,23 @@ impl Wanted {
 /// [`super::walk::MAX_TREE_DEPTH`] the results are truncated and a WARN is
 /// emitted; no error is returned.
 pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted: Wanted, out: &mut ProcessResult) {
-    let mut collector = Collector::new(source, language, wanted);
+    // ~keep SQL declarations are read by their own adapter (`super::sql`): the
+    // ~keep grammar shares node names with the generic arms while meaning
+    // ~keep something else (a plpgsql DECLARE variable is a `function_declaration`),
+    // ~keep so the language-neutral structure and symbol matchers must not see it.
+    let declarative = language == "sql";
+    let generic = Wanted {
+        structure: wanted.structure && !declarative,
+        symbols: wanted.symbols && !declarative,
+        ..wanted
+    };
+    let mut collector = Collector::new(source, language, generic);
     let truncated = walk_bounded(root, |node, depth| collector.visit(node, depth));
     warn_if_truncated(truncated, "intel::extract", language);
     collector.finish(out);
+    if wanted.structure && declarative {
+        out.structure = super::sql::structure(root, source);
+    }
     // ~keep Counts are reported once here, after the walk: a per-node event would
     // ~keep reintroduce the per-node cost this single-pass design exists to remove.
     tracing::debug!(

--- a/crates/ts-pack-core/src/intel/extract.rs
+++ b/crates/ts-pack-core/src/intel/extract.rs
@@ -69,13 +69,14 @@ impl Wanted {
 /// [`super::walk::MAX_TREE_DEPTH`] the results are truncated and a WARN is
 /// emitted; no error is returned.
 pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted: Wanted, out: &mut ProcessResult) {
-    // ~keep SQL, Just, Dockerfile and C declarations are read by their own
-    // ~keep adapters (`super::sql`, `super::just`, `super::dockerfile`, `super::c`):
-    // ~keep their grammars share node names with the generic arms while meaning
-    // ~keep something else (a plpgsql DECLARE variable is a `function_declaration`;
-    // ~keep a C prototype is a `declaration` the generic arms never see), so the
-    // ~keep language-neutral structure and symbol matchers must not see them.
-    let declarative = matches!(language, "sql" | "just" | "dockerfile" | "c");
+    // ~keep SQL, Just, Dockerfile, C and Cedar declarations are read by their own
+    // ~keep adapters (`super::sql`, `super::just`, `super::dockerfile`, `super::c`,
+    // ~keep `super::cedar`): their grammars share node names with the generic arms
+    // ~keep while meaning something else (a plpgsql DECLARE variable is a
+    // ~keep `function_declaration`; a C prototype is a `declaration` the generic
+    // ~keep arms never see), so the language-neutral structure and symbol
+    // ~keep matchers must not see them.
+    let declarative = matches!(language, "sql" | "just" | "dockerfile" | "c" | "cedar");
     let generic = Wanted {
         structure: wanted.structure && !declarative,
         symbols: wanted.symbols && !declarative,
@@ -90,6 +91,7 @@ pub(crate) fn extract_all(root: &Node<'_>, source: &str, language: &str, wanted:
             "sql" => super::sql::structure(root, source),
             "just" => super::just::structure(root, source),
             "c" => super::c::structure(root, source),
+            "cedar" => super::cedar::structure(root, source),
             _ => super::dockerfile::structure(root, source),
         };
     }

--- a/crates/ts-pack-core/src/intel/intelligence.rs
+++ b/crates/ts-pack-core/src/intel/intelligence.rs
@@ -41,10 +41,18 @@ pub(super) fn span_from_node(node: &tree_sitter::Node) -> Span {
 /// The span from `start` to `end` (exclusive) in `source`, with the trailing
 /// whitespace trimmed off, so a declaration whose grammar node swallows the
 /// blank lines after it still ends on its last line of content.
-pub(super) fn span_between(source: &str, start: usize, end: usize) -> Span {
+///
+/// `anchor` is a position already known for `start`, normally the node's own
+/// `start_position()`, which the parser has already computed. Passing it
+/// keeps this off the source prefix. Without an anchor, every call counted
+/// the newlines from byte zero, and counted them twice, so a file of many
+/// short declarations cost O(n * len) to extract. Positions are measured from
+/// the anchor across the span's own text instead, which is work proportional
+/// to the span rather than to everything before it.
+pub(super) fn span_between_from(source: &str, start: usize, end: usize, anchor: (usize, usize)) -> Span {
     let end = start + source.get(start..end).map_or(0, |text| text.trim_end().len());
-    let (start_line, start_column) = position_at(source, start);
-    let (end_line, end_column) = position_at(source, end);
+    let (start_line, start_column) = anchor;
+    let (end_line, end_column) = advance_position(source, start, anchor, end);
     Span {
         start_byte: start,
         end_byte: end,
@@ -55,9 +63,31 @@ pub(super) fn span_between(source: &str, start: usize, end: usize) -> Span {
     }
 }
 
-/// [`span_between`] over a node's own byte range.
+/// [`span_between_from`] over a node's own byte range, anchored on the
+/// position the parser already recorded for it.
 pub(super) fn span_trimmed(node: &tree_sitter::Node, source: &str) -> Span {
-    span_between(source, node.start_byte(), node.end_byte())
+    let start = node.start_position();
+    span_between_from(source, node.start_byte(), node.end_byte(), (start.row, start.column))
+}
+
+/// The position of `to`, measured forward from `from` at `position`.
+///
+/// Costs the length of the span rather than the length of the prefix before
+/// it, so a walk over many declarations stays linear in the source overall.
+fn advance_position(source: &str, from: usize, position: (usize, usize), to: usize) -> (usize, usize) {
+    let (mut row, mut column) = position;
+    let Some(text) = source.get(from..to) else {
+        return position_at(source, to);
+    };
+    let bytes = text.as_bytes();
+    match memchr::memrchr(b'\n', bytes) {
+        Some(last) => {
+            row += memchr::memchr_iter(b'\n', bytes).count();
+            column = bytes.len() - (last + 1);
+        }
+        None => column += bytes.len(),
+    }
+    (row, column)
 }
 
 /// Zero-indexed row and byte column of `byte` in `source`.

--- a/crates/ts-pack-core/src/intel/intelligence.rs
+++ b/crates/ts-pack-core/src/intel/intelligence.rs
@@ -38,6 +38,40 @@ pub(super) fn span_from_node(node: &tree_sitter::Node) -> Span {
     }
 }
 
+/// The span from `start` to `end` (exclusive) in `source`, with the trailing
+/// whitespace trimmed off, so a declaration whose grammar node swallows the
+/// blank lines after it still ends on its last line of content.
+pub(super) fn span_between(source: &str, start: usize, end: usize) -> Span {
+    let end = start + source.get(start..end).map_or(0, |text| text.trim_end().len());
+    let (start_line, start_column) = position_at(source, start);
+    let (end_line, end_column) = position_at(source, end);
+    Span {
+        start_byte: start,
+        end_byte: end,
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+    }
+}
+
+/// [`span_between`] over a node's own byte range.
+pub(super) fn span_trimmed(node: &tree_sitter::Node, source: &str) -> Span {
+    span_between(source, node.start_byte(), node.end_byte())
+}
+
+/// Zero-indexed row and byte column of `byte` in `source`.
+fn position_at(source: &str, byte: usize) -> (usize, usize) {
+    let before = &source.as_bytes()[..byte.min(source.len())];
+    let row = memchr::memchr_iter(b'\n', before).count();
+    let column = before.len()
+        - before
+            .iter()
+            .rposition(|b| *b == b'\n')
+            .map_or(0, |newline| newline + 1);
+    (row, column)
+}
+
 pub(super) fn node_text<'a>(node: &tree_sitter::Node, source: &'a str) -> &'a str {
     &source[node.start_byte()..node.end_byte()]
 }

--- a/crates/ts-pack-core/src/intel/just.rs
+++ b/crates/ts-pack-core/src/intel/just.rs
@@ -1,0 +1,53 @@
+//! Justfile declaration extraction.
+//!
+//! A recipe is the callable unit of a Justfile, so each `recipe` node is a
+//! function whose span runs from its first attribute through its last body
+//! line: the grammar's node swallows the blank lines after the body, and those
+//! are trimmed off. `alias` and `mod` are the other two named declarations.
+//! Settings, assignments and imports declare nothing callable and are skipped.
+//!
+//! Entry point: [`structure`].
+
+use tree_sitter::Node;
+
+use super::intelligence::node_text;
+use super::types::*;
+use super::walk::{Descend, walk_bounded, warn_if_truncated};
+
+/// Every recipe, alias and module in `root`, in source order.
+pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut items = Vec::new();
+    let truncated = walk_bounded(root, |node, _depth| {
+        let named = match node.kind() {
+            "recipe" => {
+                let header = child_of_kind(node, "recipe_header");
+                header
+                    .and_then(|header| header.child_by_field_name("name"))
+                    .map(|name| (StructureKind::Function, name))
+            }
+            "alias" => node
+                .child_by_field_name("left")
+                .map(|name| (StructureKind::Other("Alias".to_string()), name)),
+            "module" => node
+                .child_by_field_name("name")
+                .map(|name| (StructureKind::Module, name)),
+            _ => return Descend::Children,
+        };
+        if let Some((kind, name)) = named {
+            items.push(StructureItem {
+                kind,
+                name: Some(node_text(&name, source).to_string()),
+                span: super::intelligence::span_trimmed(node, source),
+                ..StructureItem::default()
+            });
+        }
+        Descend::Skip
+    });
+    warn_if_truncated(truncated, "intel::just", "just");
+    items
+}
+
+fn child_of_kind<'tree>(node: &Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).find(|child| child.kind() == kind)
+}

--- a/crates/ts-pack-core/src/intel/mod.rs
+++ b/crates/ts-pack-core/src/intel/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod chunking;
 pub(crate) mod data_extraction;
+pub(crate) mod dockerfile;
 pub(crate) mod elixir;
 pub(crate) mod extract;
 pub mod intelligence;

--- a/crates/ts-pack-core/src/intel/mod.rs
+++ b/crates/ts-pack-core/src/intel/mod.rs
@@ -5,6 +5,7 @@
 //! docstrings, symbols, and diagnostics.
 
 pub(crate) mod c;
+pub(crate) mod cedar;
 pub mod chunking;
 pub(crate) mod data_extraction;
 pub(crate) mod dockerfile;

--- a/crates/ts-pack-core/src/intel/mod.rs
+++ b/crates/ts-pack-core/src/intel/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod data_extraction;
 pub(crate) mod elixir;
 pub(crate) mod extract;
 pub mod intelligence;
+pub(crate) mod just;
 #[cfg(test)]
 mod legacy;
 pub(crate) mod sql;

--- a/crates/ts-pack-core/src/intel/mod.rs
+++ b/crates/ts-pack-core/src/intel/mod.rs
@@ -4,6 +4,7 @@
 //! It analyzes source code to extract structure, imports, exports, comments,
 //! docstrings, symbols, and diagnostics.
 
+pub(crate) mod c;
 pub mod chunking;
 pub(crate) mod data_extraction;
 pub(crate) mod dockerfile;

--- a/crates/ts-pack-core/src/intel/mod.rs
+++ b/crates/ts-pack-core/src/intel/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod extract;
 pub mod intelligence;
 #[cfg(test)]
 mod legacy;
+pub(crate) mod sql;
 #[cfg(test)]
 mod test_support;
 pub mod types;

--- a/crates/ts-pack-core/src/intel/sql.rs
+++ b/crates/ts-pack-core/src/intel/sql.rs
@@ -1,0 +1,256 @@
+//! SQL DDL declaration extraction.
+//!
+//! The SQL grammar parses each `CREATE` statement into a `create_*` node, so a
+//! declaration is classified by node kind and named from its `object_reference`.
+//! Two things make this more than a kind table.
+//!
+//! PostgreSQL files carry statements the grammar does not know (`GRANT`, `DO`
+//! blocks, psql meta-commands, `SET search_path` in a function header), and
+//! tree-sitter's error recovery then folds the next statement, sometimes the
+//! rest of the file, into an `ERROR` node whose children are that statement's
+//! own tokens. The declaration is still there, keyword by keyword, so
+//! [`recovered`] reads it back from the token run. Measured on 124 PostgreSQL
+//! files, 150 of roughly 550 `CREATE` statements sat inside `ERROR` nodes.
+//!
+//! The generic walk must not run on SQL at all: the grammar names a plpgsql
+//! `DECLARE` variable `function_declaration`, which the language-neutral
+//! matcher reads as a function. One proof file produced 240 such items.
+//!
+//! Entry point: [`structure`]. Nothing here walks below a matched declaration,
+//! so a `CREATE` inside a function body is part of the function, not an item.
+
+use tree_sitter::Node;
+
+use super::intelligence::node_text;
+use super::types::*;
+use super::walk::{Descend, walk_bounded, warn_if_truncated};
+
+/// Every SQL declaration in `root`, parsed or recovered, in source order.
+pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut items = Vec::new();
+    let truncated = walk_bounded(root, |node, _depth| {
+        if let Some(item) = declaration(node, source) {
+            items.push(item);
+            return Descend::Skip;
+        }
+        if node.is_error() {
+            items.extend(recovered(node, source));
+        }
+        Descend::Children
+    });
+    warn_if_truncated(truncated, "intel::sql", "sql");
+    items
+}
+
+/// The declaration a parsed `create_*` node makes, spanning the statement and
+/// its terminator.
+fn declaration(node: &Node<'_>, source: &str) -> Option<StructureItem> {
+    if !matches!(
+        node.kind(),
+        "create_table"
+            | "create_view"
+            | "create_materialized_view"
+            | "create_function"
+            | "create_procedure"
+            | "create_type"
+            | "create_index"
+            | "create_trigger"
+            | "create_policy"
+            | "create_schema"
+            | "create_database"
+            | "create_role"
+    ) {
+        return None;
+    }
+    let mut cursor = node.walk();
+    let tokens: Vec<Node<'_>> = node.children(&mut cursor).collect();
+    let head = read_head(&tokens, source)?;
+    // ~keep The terminator is the statement's sibling, not the create node's child.
+    let end = node
+        .parent()
+        .filter(|parent| parent.kind() == "statement")
+        .and_then(|parent| parent.next_sibling())
+        .filter(|sibling| sibling.kind() == ";")
+        .map_or(node.end_byte(), |terminator| terminator.end_byte());
+    Some(item(head, node.start_byte(), end, source))
+}
+
+/// Declarations whose tokens error recovery left as direct children of an
+/// `ERROR` node. A run starts at a `keyword_create` child and ends at the
+/// statement's terminator, found by [`recovered_end`].
+fn recovered(error: &Node<'_>, source: &str) -> Vec<StructureItem> {
+    let mut cursor = error.walk();
+    let tokens: Vec<Node<'_>> = error.children(&mut cursor).collect();
+    let mut items = Vec::new();
+    for (index, token) in tokens.iter().enumerate() {
+        if token.kind() != "keyword_create" {
+            continue;
+        }
+        let Some(head) = read_head(&tokens[index..], source) else {
+            continue;
+        };
+        let after_name = index + head.consumed;
+        let Some(end) = recovered_end(&tokens, after_name, head.routine) else {
+            continue;
+        };
+        items.push(item(head, token.start_byte(), end, source));
+    }
+    items
+}
+
+/// The classified head of a `CREATE` statement: its kind and qualified name,
+/// plus how many tokens the head consumed.
+struct Head {
+    kind: StructureKind,
+    name: String,
+    consumed: usize,
+    /// A function or procedure, whose body is dollar-quoted.
+    routine: bool,
+}
+
+/// Read `CREATE [OR REPLACE] [modifiers] <object> [IF NOT EXISTS] <name>` from
+/// `tokens`, which start at the `keyword_create` token. Triggers and policies
+/// are qualified by the table they are declared `ON`, because PostgreSQL scopes
+/// their names to that table.
+fn read_head(tokens: &[Node<'_>], source: &str) -> Option<Head> {
+    let mut index = 1;
+    let mut object = None;
+    while index < tokens.len() {
+        let kind = tokens[index].kind();
+        index += 1;
+        match kind {
+            "keyword_or"
+            | "keyword_replace"
+            | "keyword_unique"
+            | "keyword_temp"
+            | "keyword_temporary"
+            | "keyword_materialized"
+            | "keyword_unlogged" => {}
+            keyword if keyword.starts_with("keyword_") => {
+                object = Some(keyword);
+                break;
+            }
+            _ => return None,
+        }
+    }
+    let object = object?;
+    let kind = match object {
+        "keyword_table" | "keyword_view" => StructureKind::Struct,
+        "keyword_function" | "keyword_procedure" => StructureKind::Function,
+        "keyword_type" => StructureKind::Other("Type".to_string()),
+        "keyword_index" => StructureKind::Other("Index".to_string()),
+        "keyword_trigger" => StructureKind::Other("Trigger".to_string()),
+        "keyword_policy" => StructureKind::Other("Policy".to_string()),
+        "keyword_schema" | "keyword_database" => StructureKind::Module,
+        "keyword_role" => StructureKind::Other("Role".to_string()),
+        _ => return None,
+    };
+    while index < tokens.len()
+        && matches!(
+            tokens[index].kind(),
+            "keyword_if" | "keyword_not" | "keyword_exists" | "keyword_concurrently"
+        )
+    {
+        index += 1;
+    }
+    let mut name = object_name(tokens.get(index)?, source)?;
+    index += 1;
+    if matches!(object, "keyword_trigger" | "keyword_policy") {
+        let on = tokens[index..].iter().position(|token| token.kind() == "keyword_on")? + index;
+        let table = object_name(tokens.get(on + 1)?, source)?;
+        name = format!("{table}.{name}");
+        index = on + 2;
+    }
+    Some(Head {
+        kind,
+        name,
+        consumed: index,
+        routine: matches!(object, "keyword_function" | "keyword_procedure"),
+    })
+}
+
+/// The name an object token carries, schema-qualified when the reference is,
+/// with the double quotes of a quoted identifier removed. A psql variable
+/// (`:db_name`, `:"role"`) parses as an `ERROR` colon and is not a name, and
+/// a keyword where the name should be means the name was lost to recovery.
+fn object_name(token: &Node<'_>, source: &str) -> Option<String> {
+    match token.kind() {
+        "object_reference" => {
+            let name = plain(node_text(&token.child_by_field_name("name")?, source));
+            Some(match token.child_by_field_name("schema") {
+                Some(schema) => format!("{}.{name}", plain(node_text(&schema, source))),
+                None => name.to_string(),
+            })
+        }
+        "identifier" => Some(plain(node_text(token, source)).to_string()),
+        "field" => object_name(&token.child_by_field_name("name")?, source),
+        "invocation" => {
+            let mut cursor = token.walk();
+            let reference = token
+                .named_children(&mut cursor)
+                .find(|child| child.kind() == "object_reference")?;
+            object_name(&reference, source)
+        }
+        _ => None,
+    }
+}
+
+fn plain(identifier: &str) -> &str {
+    identifier
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .unwrap_or(identifier)
+}
+
+/// Where a recovered statement ends: at the dollar quote closing a routine's
+/// body, else at the first `;` token, stopping short of the next parsed
+/// statement or `CREATE` keyword so a lost terminator cannot pull the span
+/// over its neighbour.
+fn recovered_end(tokens: &[Node<'_>], from: usize, routine: bool) -> Option<usize> {
+    if routine && let Some(open) = leaves(&tokens[from..]).find(|leaf| leaf.kind() == "dollar_quote") {
+        let tag = open.byte_range();
+        let mut after_open = leaves(&tokens[from..]).skip_while(|leaf| leaf.id() != open.id());
+        after_open.next();
+        if let Some(close) =
+            after_open.find(|leaf| leaf.kind() == "dollar_quote" && leaf.byte_range().len() == tag.len())
+        {
+            return Some(close.end_byte());
+        }
+    }
+    let mut end = None;
+    for token in &tokens[from..] {
+        if matches!(token.kind(), "statement" | "keyword_create") {
+            break;
+        }
+        if let Some(terminator) = leaves(std::slice::from_ref(token)).find(|leaf| leaf.kind() == ";") {
+            return Some(terminator.end_byte());
+        }
+        end = Some(token.end_byte());
+    }
+    end
+}
+
+/// The leaf tokens under `tokens`, in source order.
+fn leaves<'tree>(tokens: &[Node<'tree>]) -> impl Iterator<Item = Node<'tree>> {
+    let mut pending: Vec<Node<'tree>> = tokens.iter().rev().copied().collect();
+    std::iter::from_fn(move || {
+        while let Some(node) = pending.pop() {
+            if node.child_count() == 0 {
+                return Some(node);
+            }
+            let mut cursor = node.walk();
+            let children: Vec<Node<'tree>> = node.children(&mut cursor).collect();
+            pending.extend(children.into_iter().rev());
+        }
+        None
+    })
+}
+
+fn item(head: Head, start: usize, end: usize, source: &str) -> StructureItem {
+    StructureItem {
+        kind: head.kind,
+        name: Some(head.name),
+        span: super::intelligence::span_between(source, start, end),
+        ..StructureItem::default()
+    }
+}

--- a/crates/ts-pack-core/src/intel/sql.rs
+++ b/crates/ts-pack-core/src/intel/sql.rs
@@ -1,44 +1,65 @@
 //! SQL DDL declaration extraction.
 //!
 //! The SQL grammar parses each `CREATE` statement into a `create_*` node, so a
-//! declaration is classified by node kind and named from its `object_reference`.
-//! Two things make this more than a kind table.
+//! declaration is classified by node kind and named from its tokens. Two things
+//! make this more than a kind table.
 //!
 //! PostgreSQL files carry statements the grammar does not know (`GRANT`, `DO`
 //! blocks, psql meta-commands, `SET search_path` in a function header), and
 //! tree-sitter's error recovery then folds the next statement, sometimes the
-//! rest of the file, into an `ERROR` node whose children are that statement's
-//! own tokens. The declaration is still there, keyword by keyword, so
-//! [`recovered`] reads it back from the token run. Measured on 124 PostgreSQL
-//! files, 150 of roughly 550 `CREATE` statements sat inside `ERROR` nodes.
+//! rest of the file, into `ERROR` nodes that keep the statement's tokens but
+//! not its node. The declaration is still there, keyword by keyword, so the
+//! second pass reads every `CREATE` outside a parsed declaration back from the
+//! leaf token stream. Measured on 124 PostgreSQL files, 150 of roughly 550
+//! `CREATE` statements sat inside `ERROR` nodes.
 //!
 //! The generic walk must not run on SQL at all: the grammar names a plpgsql
 //! `DECLARE` variable `function_declaration`, which the language-neutral
 //! matcher reads as a function. One proof file produced 240 such items.
 //!
-//! Entry point: [`structure`]. Nothing here walks below a matched declaration,
+//! Entry point: [`structure`]. Nothing here looks below a matched declaration,
 //! so a `CREATE` inside a function body is part of the function, not an item.
 
 use tree_sitter::Node;
 
-use super::intelligence::node_text;
+use super::intelligence::{node_text, span_between};
 use super::types::*;
 use super::walk::{Descend, walk_bounded, warn_if_truncated};
 
 /// Every SQL declaration in `root`, parsed or recovered, in source order.
 pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
     let mut items = Vec::new();
+    let mut parsed: Vec<(usize, usize)> = Vec::new();
     let truncated = walk_bounded(root, |node, _depth| {
+        if !node.kind().starts_with("create_") {
+            return Descend::Children;
+        }
         if let Some(item) = declaration(node, source) {
+            parsed.push((item.span.start_byte, item.span.end_byte));
             items.push(item);
-            return Descend::Skip;
         }
-        if node.is_error() {
-            items.extend(recovered(node, source));
-        }
-        Descend::Children
+        Descend::Skip
     });
     warn_if_truncated(truncated, "intel::sql", "sql");
+
+    let leaves: Vec<Node<'_>> = leaves(root).collect();
+    for (index, leaf) in leaves.iter().enumerate() {
+        if leaf.kind() != "keyword_create"
+            || parsed
+                .iter()
+                .any(|(start, end)| (start..end).contains(&&leaf.start_byte()))
+        {
+            continue;
+        }
+        let Some(head) = read_head(&leaves, index, source) else {
+            continue;
+        };
+        let Some(end) = recovered_end(&leaves, head.consumed, head.routine) else {
+            continue;
+        };
+        items.push(item(head, leaf.start_byte(), end, source));
+    }
+    items.sort_by_key(|item| item.span.start_byte);
     items
 }
 
@@ -62,44 +83,27 @@ fn declaration(node: &Node<'_>, source: &str) -> Option<StructureItem> {
     ) {
         return None;
     }
-    let mut cursor = node.walk();
-    let tokens: Vec<Node<'_>> = node.children(&mut cursor).collect();
-    let head = read_head(&tokens, source)?;
+    let leaves: Vec<Node<'_>> = leaves(node).collect();
+    let head = read_head(&leaves, 0, source)?;
     // ~keep The terminator is the statement's sibling, not the create node's child.
-    let end = node
+    let after_node = node
         .parent()
         .filter(|parent| parent.kind() == "statement")
         .and_then(|parent| parent.next_sibling())
         .filter(|sibling| sibling.kind() == ";")
         .map_or(node.end_byte(), |terminator| terminator.end_byte());
+    // ~keep Error recovery can run a routine's body past its own closing quote and
+    // ~keep swallow the next statement into it. The body ends at that quote, and
+    // ~keep the swallowed statement is read back by the recovery pass.
+    let end = match head.routine.then(|| routine_close(&leaves, head.consumed)).flatten() {
+        Some(close) if close + 1 < leaves.len() => terminated(&leaves, close),
+        _ => after_node,
+    };
     Some(item(head, node.start_byte(), end, source))
 }
 
-/// Declarations whose tokens error recovery left as direct children of an
-/// `ERROR` node. A run starts at a `keyword_create` child and ends at the
-/// statement's terminator, found by [`recovered_end`].
-fn recovered(error: &Node<'_>, source: &str) -> Vec<StructureItem> {
-    let mut cursor = error.walk();
-    let tokens: Vec<Node<'_>> = error.children(&mut cursor).collect();
-    let mut items = Vec::new();
-    for (index, token) in tokens.iter().enumerate() {
-        if token.kind() != "keyword_create" {
-            continue;
-        }
-        let Some(head) = read_head(&tokens[index..], source) else {
-            continue;
-        };
-        let after_name = index + head.consumed;
-        let Some(end) = recovered_end(&tokens, after_name, head.routine) else {
-            continue;
-        };
-        items.push(item(head, token.start_byte(), end, source));
-    }
-    items
-}
-
 /// The classified head of a `CREATE` statement: its kind and qualified name,
-/// plus how many tokens the head consumed.
+/// plus the index of the first leaf after the head.
 struct Head {
     kind: StructureKind,
     name: String,
@@ -109,17 +113,18 @@ struct Head {
 }
 
 /// Read `CREATE [OR REPLACE] [modifiers] <object> [IF NOT EXISTS] <name>` from
-/// `tokens`, which start at the `keyword_create` token. Triggers and policies
-/// are qualified by the table they are declared `ON`, because PostgreSQL scopes
-/// their names to that table.
-fn read_head(tokens: &[Node<'_>], source: &str) -> Option<Head> {
-    let mut index = 1;
+/// the leaves starting at `start`, a `keyword_create`. Triggers and policies
+/// are qualified by the table they are declared `ON`, because PostgreSQL
+/// scopes their names to that table.
+fn read_head(leaves: &[Node<'_>], start: usize, source: &str) -> Option<Head> {
+    let mut index = start + 1;
     let mut object = None;
-    while index < tokens.len() {
-        let kind = tokens[index].kind();
+    while index < leaves.len() {
+        let kind = leaves[index].kind();
         index += 1;
         match kind {
-            "keyword_or"
+            "comment"
+            | "keyword_or"
             | "keyword_replace"
             | "keyword_unique"
             | "keyword_temp"
@@ -145,21 +150,19 @@ fn read_head(tokens: &[Node<'_>], source: &str) -> Option<Head> {
         "keyword_role" => StructureKind::Other("Role".to_string()),
         _ => return None,
     };
-    while index < tokens.len()
+    while index < leaves.len()
         && matches!(
-            tokens[index].kind(),
-            "keyword_if" | "keyword_not" | "keyword_exists" | "keyword_concurrently"
+            leaves[index].kind(),
+            "comment" | "keyword_if" | "keyword_not" | "keyword_exists" | "keyword_concurrently"
         )
     {
         index += 1;
     }
-    let mut name = object_name(tokens.get(index)?, source)?;
-    index += 1;
+    let mut name = qualified_name(leaves, &mut index, source)?;
     if matches!(object, "keyword_trigger" | "keyword_policy") {
-        let on = tokens[index..].iter().position(|token| token.kind() == "keyword_on")? + index;
-        let table = object_name(tokens.get(on + 1)?, source)?;
+        index = leaves[index..].iter().position(|leaf| leaf.kind() == "keyword_on")? + index + 1;
+        let table = qualified_name(leaves, &mut index, source)?;
         name = format!("{table}.{name}");
-        index = on + 2;
     }
     Some(Head {
         kind,
@@ -169,30 +172,33 @@ fn read_head(tokens: &[Node<'_>], source: &str) -> Option<Head> {
     })
 }
 
-/// The name an object token carries, schema-qualified when the reference is,
-/// with the double quotes of a quoted identifier removed. A psql variable
-/// (`:db_name`, `:"role"`) parses as an `ERROR` colon and is not a name, and
-/// a keyword where the name should be means the name was lost to recovery.
-fn object_name(token: &Node<'_>, source: &str) -> Option<String> {
-    match token.kind() {
-        "object_reference" => {
-            let name = plain(node_text(&token.child_by_field_name("name")?, source));
-            Some(match token.child_by_field_name("schema") {
-                Some(schema) => format!("{}.{name}", plain(node_text(&schema, source))),
-                None => name.to_string(),
-            })
-        }
-        "identifier" => Some(plain(node_text(token, source)).to_string()),
-        "field" => object_name(&token.child_by_field_name("name")?, source),
-        "invocation" => {
-            let mut cursor = token.walk();
-            let reference = token
-                .named_children(&mut cursor)
-                .find(|child| child.kind() == "object_reference")?;
-            object_name(&reference, source)
-        }
-        _ => None,
+/// The dotted name at `leaves[*index]`, advancing past it: identifiers joined
+/// by dots, with the double quotes of a quoted identifier removed. A schema
+/// that is also a keyword (`public.name`) arrives as `keyword_public` before
+/// the dot, so a keyword followed by a dot is a name part. A psql variable
+/// (`:db_name`, `:"role"`) is an error colon before the identifier and is not
+/// a name; a keyword where the name should be means the name was lost.
+fn qualified_name(leaves: &[Node<'_>], index: &mut usize, source: &str) -> Option<String> {
+    if leaves
+        .get(*index - 1)
+        .is_some_and(|before| node_text(before, source) == ":")
+    {
+        return None;
     }
+    let mut parts = Vec::new();
+    while let Some(leaf) = leaves.get(*index) {
+        let dotted = leaves.get(*index + 1).is_some_and(|next| next.kind() == ".");
+        if leaf.kind() != "identifier" && !(leaf.kind().starts_with("keyword_") && dotted) {
+            break;
+        }
+        parts.push(plain(node_text(leaf, source)));
+        *index += 1;
+        if !dotted {
+            break;
+        }
+        *index += 1;
+    }
+    if parts.is_empty() { None } else { Some(parts.join(".")) }
 }
 
 fn plain(identifier: &str) -> &str {
@@ -203,36 +209,48 @@ fn plain(identifier: &str) -> &str {
 }
 
 /// Where a recovered statement ends: at the dollar quote closing a routine's
-/// body, else at the first `;` token, stopping short of the next parsed
-/// statement or `CREATE` keyword so a lost terminator cannot pull the span
-/// over its neighbour.
-fn recovered_end(tokens: &[Node<'_>], from: usize, routine: bool) -> Option<usize> {
-    if routine && let Some(open) = leaves(&tokens[from..]).find(|leaf| leaf.kind() == "dollar_quote") {
-        let tag = open.byte_range();
-        let mut after_open = leaves(&tokens[from..]).skip_while(|leaf| leaf.id() != open.id());
-        after_open.next();
-        if let Some(close) =
-            after_open.find(|leaf| leaf.kind() == "dollar_quote" && leaf.byte_range().len() == tag.len())
-        {
-            return Some(close.end_byte());
-        }
+/// body, else at the first `;`, stopping short of the next `CREATE` so a lost
+/// terminator cannot pull the span over its neighbour.
+fn recovered_end(leaves: &[Node<'_>], from: usize, routine: bool) -> Option<usize> {
+    if routine && let Some(close) = routine_close(leaves, from) {
+        return Some(terminated(leaves, close));
     }
     let mut end = None;
-    for token in &tokens[from..] {
-        if matches!(token.kind(), "statement" | "keyword_create") {
-            break;
+    for leaf in &leaves[from..] {
+        match leaf.kind() {
+            ";" => return Some(leaf.end_byte()),
+            "keyword_create" => break,
+            _ => end = Some(leaf.end_byte()),
         }
-        if let Some(terminator) = leaves(std::slice::from_ref(token)).find(|leaf| leaf.kind() == ";") {
-            return Some(terminator.end_byte());
-        }
-        end = Some(token.end_byte());
     }
     end
 }
 
-/// The leaf tokens under `tokens`, in source order.
-fn leaves<'tree>(tokens: &[Node<'tree>]) -> impl Iterator<Item = Node<'tree>> {
-    let mut pending: Vec<Node<'tree>> = tokens.iter().rev().copied().collect();
+/// The index of the dollar quote closing the body that opens after `from`:
+/// the next quote of the same length, since PostgreSQL does not nest a tag
+/// inside itself.
+fn routine_close(leaves: &[Node<'_>], from: usize) -> Option<usize> {
+    let quote = |leaf: &Node<'_>| leaf.kind() == "dollar_quote" && !leaf.byte_range().is_empty();
+    let open = from + leaves[from..].iter().position(quote)?;
+    let tag = leaves[open].byte_range().len();
+    let close = leaves[open + 1..]
+        .iter()
+        .position(|leaf| quote(leaf) && leaf.byte_range().len() == tag)?;
+    Some(open + 1 + close)
+}
+
+/// The end of the statement whose last token is `leaves[index]`, taking in the
+/// terminator when it is the next leaf.
+fn terminated(leaves: &[Node<'_>], index: usize) -> usize {
+    match leaves.get(index + 1) {
+        Some(next) if next.kind() == ";" => next.end_byte(),
+        _ => leaves[index].end_byte(),
+    }
+}
+
+/// The leaf tokens under `root`, in source order, without native recursion.
+fn leaves<'tree>(root: &Node<'tree>) -> impl Iterator<Item = Node<'tree>> {
+    let mut pending: Vec<Node<'tree>> = vec![*root];
     std::iter::from_fn(move || {
         while let Some(node) = pending.pop() {
             if node.child_count() == 0 {
@@ -250,7 +268,7 @@ fn item(head: Head, start: usize, end: usize, source: &str) -> StructureItem {
     StructureItem {
         kind: head.kind,
         name: Some(head.name),
-        span: super::intelligence::span_between(source, start, end),
+        span: span_between(source, start, end),
         ..StructureItem::default()
     }
 }

--- a/crates/ts-pack-core/src/intel/sql.rs
+++ b/crates/ts-pack-core/src/intel/sql.rs
@@ -92,11 +92,13 @@ fn declaration(node: &Node<'_>, source: &str) -> Option<StructureItem> {
         .and_then(|parent| parent.next_sibling())
         .filter(|sibling| sibling.kind() == ";")
         .map_or(node.end_byte(), |terminator| terminator.end_byte());
-    // ~keep Error recovery can run a routine's body past its own closing quote and
-    // ~keep swallow the next statement into it. The body ends at that quote, and
-    // ~keep the swallowed statement is read back by the recovery pass.
-    let end = match head.routine.then(|| routine_close(&leaves, head.consumed)).flatten() {
-        Some(close) if close + 1 < leaves.len() => terminated(&leaves, close),
+    // ~keep Error recovery can run a node past its own end (a routine past its
+    // ~keep closing quote, a table past its terminator) and swallow the statements
+    // ~keep after it. No declaration holds a `;` of its own, so the node ends at
+    // ~keep the first one, and the swallowed statements are read back by the
+    // ~keep recovery pass.
+    let end = match recovered_end(&leaves, head.consumed, head.routine) {
+        Some(inside) if inside < node.end_byte() => inside,
         _ => after_node,
     };
     Some(item(head, node.start_byte(), end, source))

--- a/crates/ts-pack-core/src/intel/sql.rs
+++ b/crates/ts-pack-core/src/intel/sql.rs
@@ -22,7 +22,7 @@
 
 use tree_sitter::Node;
 
-use super::intelligence::{node_text, span_between};
+use super::intelligence::{node_text, span_between_from};
 use super::types::*;
 use super::walk::{Descend, walk_bounded, warn_if_truncated};
 
@@ -57,7 +57,7 @@ pub(super) fn structure(root: &Node<'_>, source: &str) -> Vec<StructureItem> {
         let Some(end) = recovered_end(&leaves, head.consumed, head.routine) else {
             continue;
         };
-        items.push(item(head, leaf.start_byte(), end, source));
+        items.push(item(head, leaf, end, source));
     }
     items.sort_by_key(|item| item.span.start_byte);
     items
@@ -101,7 +101,7 @@ fn declaration(node: &Node<'_>, source: &str) -> Option<StructureItem> {
         Some(inside) if inside < node.end_byte() => inside,
         _ => after_node,
     };
-    Some(item(head, node.start_byte(), end, source))
+    Some(item(head, node, end, source))
 }
 
 /// The classified head of a `CREATE` statement: its kind and qualified name,
@@ -162,7 +162,15 @@ fn read_head(leaves: &[Node<'_>], start: usize, source: &str) -> Option<Head> {
     }
     let mut name = qualified_name(leaves, &mut index, source)?;
     if matches!(object, "keyword_trigger" | "keyword_policy") {
-        index = leaves[index..].iter().position(|leaf| leaf.kind() == "keyword_on")? + index + 1;
+        // ~keep get(index..), not leaves[index..]: `qualified_name` can leave
+        // ~keep the index at the end of the leaves, and a truncated
+        // ~keep `CREATE TRIGGER foo` at end of file is exactly that shape.
+        index = leaves
+            .get(index..)?
+            .iter()
+            .position(|leaf| leaf.kind() == "keyword_on")?
+            + index
+            + 1;
         let table = qualified_name(leaves, &mut index, source)?;
         name = format!("{table}.{name}");
     }
@@ -181,8 +189,14 @@ fn read_head(leaves: &[Node<'_>], start: usize, source: &str) -> Option<Head> {
 /// (`:db_name`, `:"role"`) is an error colon before the identifier and is not
 /// a name; a keyword where the name should be means the name was lost.
 fn qualified_name(leaves: &[Node<'_>], index: &mut usize, source: &str) -> Option<String> {
-    if leaves
-        .get(*index - 1)
+    // ~keep checked_sub, not `*index - 1`: the index is a usize, and a caller
+    // ~keep that starts a name at the first leaf would wrap it rather than
+    // ~keep look behind. Reaching here with 0 needs a `CREATE` at index 0,
+    // ~keep which `read_head` cannot produce today; the subtraction is still
+    // ~keep wrong on its own terms and this costs nothing.
+    if (*index)
+        .checked_sub(1)
+        .and_then(|before| leaves.get(before))
         .is_some_and(|before| node_text(before, source) == ":")
     {
         return None;
@@ -266,11 +280,15 @@ fn leaves<'tree>(root: &Node<'tree>) -> impl Iterator<Item = Node<'tree>> {
     })
 }
 
-fn item(head: Head, start: usize, end: usize, source: &str) -> StructureItem {
+/// `start_node` is the node the statement starts at, whose position the
+/// parser has already computed; the span is measured from there rather than
+/// by counting newlines from the top of the file for every statement.
+fn item(head: Head, start_node: &Node<'_>, end: usize, source: &str) -> StructureItem {
+    let start = start_node.start_position();
     StructureItem {
         kind: head.kind,
         name: Some(head.name),
-        span: span_between(source, start, end),
+        span: span_between_from(source, start_node.start_byte(), end, (start.row, start.column)),
         ..StructureItem::default()
     }
 }

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -461,6 +461,93 @@ fn c_definitions_prototypes_aggregates_typedefs_and_macros_are_declarations() {
     assert!(result.symbols.is_empty(), "C emits no flat symbols");
 }
 
+/// The line and column of every span, recomputed from the source text alone.
+///
+/// Independent of how the adapters arrive at a position, so it holds whether
+/// they count from the top of the file or from a position the parser gave
+/// them.
+fn line_and_column(source: &str, byte: usize) -> (usize, usize) {
+    let before = &source.as_bytes()[..byte.min(source.len())];
+    let line = before.iter().filter(|b| **b == b'\n').count();
+    let column = before.len() - before.iter().rposition(|b| *b == b'\n').map_or(0, |at| at + 1);
+    (line, column)
+}
+
+fn assert_spans_agree_with_the_source(source: &str, language: &str) {
+    let result = extract(source, language);
+    assert!(
+        !result.structure.is_empty(),
+        "{language}: nothing extracted, so the spans prove nothing"
+    );
+    let mut pending: Vec<&StructureItem> = result.structure.iter().collect();
+    while let Some(item) = pending.pop() {
+        pending.extend(item.children.iter());
+        let span = &item.span;
+        assert!(
+            span.start_byte <= span.end_byte && span.end_byte <= source.len(),
+            "{language}: {:?} has byte range {}..{} in a {} byte source",
+            item.name,
+            span.start_byte,
+            span.end_byte,
+            source.len()
+        );
+        assert!(
+            source.is_char_boundary(span.start_byte) && source.is_char_boundary(span.end_byte),
+            "{language}: {:?} splits a character",
+            item.name
+        );
+        assert_eq!(
+            (span.start_line, span.start_column),
+            line_and_column(source, span.start_byte),
+            "{language}: {:?} start position disagrees with its byte offset",
+            item.name
+        );
+        assert_eq!(
+            (span.end_line, span.end_column),
+            line_and_column(source, span.end_byte),
+            "{language}: {:?} end position disagrees with its byte offset",
+            item.name
+        );
+    }
+}
+
+/// Positions are anchored on the position the parser already recorded for a
+/// node, rather than counted from the top of the file for every declaration,
+/// which cost O(declarations * length) to extract. The saving is only worth
+/// having if the positions are unchanged, so every span each adapter reports
+/// is checked against the source it came from.
+///
+/// Columns are counted in bytes, so a multi-byte character is where an
+/// anchored count and a counted-from-zero one would part company; the
+/// fixtures carry one on a line before a declaration and inside one.
+#[test]
+fn every_declaration_span_agrees_with_its_own_source() {
+    assert_spans_agree_with_the_source(C_SOURCE, "c");
+    assert_spans_agree_with_the_source(C_HEADER, "c");
+    assert_spans_agree_with_the_source(SQL_DDL, "sql");
+    assert_spans_agree_with_the_source(JUSTFILE, "just");
+    assert_spans_agree_with_the_source(DOCKERFILE, "dockerfile");
+    assert_spans_agree_with_the_source(CEDAR, "cedar");
+
+    assert_spans_agree_with_the_source(
+        "\
+// primera línea, uno más
+int café(int x);
+
+/* ± ² ³ */
+struct punto { int x; };
+
+#define TAMAÑO 10
+int main(void) { return TAMAÑO; }
+",
+        "c",
+    );
+    assert_spans_agree_with_the_source(
+        "-- ¿cuántos?\nCREATE TABLE café (id int);\nCREATE VIEW ± AS SELECT 1;\n",
+        "sql",
+    );
+}
+
 /// C spells a function declaration more than one way, and requiring the
 /// function declarator to apply to a bare identifier saw only the plainest.
 /// A redundant pair of parentheses around the name is legal, and a function

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -1,0 +1,175 @@
+//! Declaration coverage for the code-shaped repository formats. Their grammars
+//! name nodes the generic matcher misreads, so each has its own adapter,
+//! exercised here on the shapes real repository files take.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
+
+fn extract(source: &str, language: &str) -> ProcessResult {
+    process(source, &ProcessConfig::new(language).all()).expect("real grammar required; build with TSLP_LANGUAGES=sql")
+}
+
+/// (name, kind, start_line, end_line) for each item, top level only.
+fn summary(items: &[StructureItem]) -> Vec<(Option<&str>, &StructureKind, usize, usize)> {
+    items
+        .iter()
+        .map(|item| {
+            (
+                item.name.as_deref(),
+                &item.kind,
+                item.span.start_line,
+                item.span.end_line,
+            )
+        })
+        .collect()
+}
+
+fn other(label: &str) -> StructureKind {
+    StructureKind::Other(label.to_string())
+}
+
+const SQL_DDL: &str = "\
+-- comment
+CREATE SCHEMA IF NOT EXISTS engram;
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE ROLE engram_app LOGIN;
+CREATE TABLE engram.thoughts (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL
+);
+CREATE TABLE IF NOT EXISTS \"Quoted\".\"My Table\" (id int);
+CREATE UNIQUE INDEX thoughts_tenant_idx ON engram.thoughts (tenant_id, id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS other_idx ON thoughts USING btree (id);
+CREATE OR REPLACE FUNCTION engram_current_tenant()
+RETURNS uuid
+LANGUAGE sql STABLE AS $$
+  SELECT current_setting('engram.tenant_id', true)::uuid
+$$;
+CREATE FUNCTION public.sync_lexemes() RETURNS trigger LANGUAGE plpgsql AS $body$
+BEGIN
+  INSERT INTO x VALUES (1);
+  RETURN NEW;
+END;
+$body$;
+CREATE TRIGGER engram_sync_symbol_lexemes AFTER INSERT OR UPDATE ON symbol_cards
+  FOR EACH ROW EXECUTE FUNCTION sync_lexemes();
+CREATE POLICY tenant_isolation ON engram.thoughts
+  USING (tenant_id = engram_current_tenant());
+CREATE OR REPLACE VIEW engram.recent AS SELECT * FROM engram.thoughts;
+CREATE MATERIALIZED VIEW engram.stats AS SELECT count(*) FROM engram.thoughts;
+CREATE TYPE mood AS ENUM ('sad', 'ok');
+CREATE TEMP TABLE scratch (id int);
+CREATE SEQUENCE seq1;
+ALTER TABLE engram.thoughts ENABLE ROW LEVEL SECURITY;
+SELECT 1;
+";
+
+#[test]
+fn sql_ddl_objects_have_kinds_qualified_names_and_statement_spans() {
+    let result = extract(SQL_DDL, "sql");
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("engram"), &StructureKind::Module, 1, 1),
+            (Some("engram_app"), &other("Role"), 3, 3),
+            (Some("engram.thoughts"), &StructureKind::Struct, 4, 7),
+            (Some("Quoted.My Table"), &StructureKind::Struct, 8, 8),
+            (Some("thoughts_tenant_idx"), &other("Index"), 9, 9),
+            (Some("other_idx"), &other("Index"), 10, 10),
+            (Some("engram_current_tenant"), &StructureKind::Function, 11, 15),
+            (Some("public.sync_lexemes"), &StructureKind::Function, 16, 21),
+            (
+                Some("symbol_cards.engram_sync_symbol_lexemes"),
+                &other("Trigger"),
+                22,
+                23
+            ),
+            (Some("engram.thoughts.tenant_isolation"), &other("Policy"), 24, 25),
+            (Some("engram.recent"), &StructureKind::Struct, 26, 26),
+            (Some("engram.stats"), &StructureKind::Struct, 27, 27),
+            (Some("mood"), &other("Type"), 28, 28),
+            (Some("scratch"), &StructureKind::Struct, 29, 29),
+        ]
+    );
+    // The statement span includes its terminator and nothing after it.
+    let function = &result.structure[6].span;
+    assert!(SQL_DDL[function.start_byte..function.end_byte].ends_with("$$;"));
+    assert!(result.structure.iter().all(|item| item.children.is_empty()));
+    assert!(result.symbols.is_empty(), "SQL emits no flat symbols");
+}
+
+#[test]
+fn sql_declarations_folded_into_error_recovery_keep_exact_spans() {
+    // `SET search_path` in a function header and the GRANT are not in the
+    // grammar; recovery folds everything after each into an ERROR node.
+    let source = "\
+CREATE OR REPLACE FUNCTION engram_purge(p_tenant text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $fn$
+DECLARE
+  n_cards integer;
+BEGIN
+  DELETE FROM symbol_cards WHERE tenant_id = p_tenant;
+  RETURN jsonb_build_object('cards', n_cards);
+END;
+$fn$;
+GRANT SELECT ON symbol_cards TO engram_app;
+CREATE UNIQUE INDEX symbol_cards_id_key ON symbol_cards (id);
+CREATE POLICY symbol_cards_rls ON symbol_cards
+  USING (tenant_id = engram_current_tenant());
+CREATE OR REPLACE FUNCTION engram_sync() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN NEW;
+END;
+$$;
+CREATE TABLE code_repos (id uuid PRIMARY KEY);
+";
+    let result = extract(source, "sql");
+    assert!(result.metrics.error_count > 0, "the fixture must exercise recovery");
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("engram_purge"), &StructureKind::Function, 0, 12),
+            (Some("symbol_cards_id_key"), &other("Index"), 14, 14),
+            (Some("symbol_cards.symbol_cards_rls"), &other("Policy"), 15, 16),
+            (Some("engram_sync"), &StructureKind::Function, 17, 21),
+            (Some("code_repos"), &StructureKind::Struct, 22, 22),
+        ]
+    );
+    for item in &result.structure {
+        let text = &source[item.span.start_byte..item.span.end_byte];
+        assert!(text.starts_with("CREATE"), "{text}");
+        assert!(text.ends_with(';'), "{text}");
+    }
+}
+
+#[test]
+fn sql_lost_names_variables_and_bodies_are_not_declarations() {
+    // A CREATE inside a recognised body belongs to the routine. A psql
+    // variable, a keyword where the name should be (GRANT CREATE ON), and a
+    // format placeholder are not names, so those statements yield nothing.
+    let source = "\
+CREATE OR REPLACE FUNCTION counted() RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+  v_total integer;
+BEGIN
+  CREATE TEMP TABLE inner_scratch (id int);
+  SELECT count(*) INTO v_total FROM symbol_cards;
+  RETURN v_total;
+END;
+$$;
+GRANT CREATE ON SCHEMA public TO engram;
+CREATE DATABASE :db_name OWNER engram;
+CREATE ROLE :\"role_name\" LOGIN;
+CREATE FUNCTION %s(%s) RETURNS %s;
+";
+    let result = extract(source, "sql");
+    assert!(result.metrics.error_count > 0, "the fixture must exercise recovery");
+    assert_eq!(
+        summary(&result.structure),
+        vec![(Some("counted"), &StructureKind::Function, 0, 8)]
+    );
+}

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -176,6 +176,53 @@ CREATE FUNCTION %s(%s) RETURNS %s;
     );
 }
 
+#[test]
+fn sql_recovery_reads_a_schema_the_lexer_handed_over_as_a_keyword() {
+    // Shrunk from a real proof file: the first body derails the parser, which
+    // runs the function past its own closing quote and hands the next header
+    // over as `keyword_public`, `.`, then the bare name.
+    let source = "\
+    CREATE OR REPLACE FUNCTION public.engram_floor_complete(p_tenant text, p_set_id uuid)
+     RETURNS boolean
+    AS $function$
+    DECLARE
+      -- SQLSTATE 55P03 here instead of parking this tenant connection.
+                 AND  sv.card_id   = sc.id
+                 AND  sv.set_id    = sc.set_id
+             );
+
+      RETURN v_floorless = 0;
+    END;
+    $function$
+;
+    CREATE OR REPLACE FUNCTION public.engram_complete(p_tenant text, p_floor_complete boolean)
+     RETURNS text
+     LANGUAGE plpgsql
+     SECURITY DEFINER
+     SET search_path TO 'public', 'pg_catalog'
+    AS $function$
+    DECLARE
+      v_repo             text;
+    BEGIN
+      RETURN 1;
+    END;
+    $function$
+;
+";
+    let result = extract(source, "sql");
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("public.engram_floor_complete"), &StructureKind::Function, 0, 12),
+            (Some("public.engram_complete"), &StructureKind::Function, 13, 25),
+        ]
+    );
+    for item in &result.structure {
+        let text = &source[item.span.start_byte..item.span.end_byte];
+        assert!(text.starts_with("CREATE") && text.ends_with("$function$\n;"), "{text}");
+    }
+}
+
 const JUSTFILE: &str = "\
 set shell := [\"bash\", \"-eu\", \"-c\"]
 

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -223,6 +223,36 @@ fn sql_recovery_reads_a_schema_the_lexer_handed_over_as_a_keyword() {
     }
 }
 
+#[test]
+fn sql_table_the_parser_ran_past_its_terminator_ends_there() {
+    // Shrunk from a real DDL proof: the REFERENCES clause and the GRANTs after
+    // it fold the next CREATE TABLE into the first table's node, and the lexer
+    // drops that second table's name token, so it yields nothing rather than
+    // a name it never had.
+    let source = "\
+CREATE TABLE tinker_platform_release_files (
+  platform_file_id     uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform_release_id  uuid        NOT NULL
+    REFERENCES tinker_platform_releases (platform_release_id) ON DELETE CASCADE,
+  CONSTRAINT tinker_platform_release_files_path_key UNIQUE (platform_release_id, rel_path)
+);
+GRANT SELECT, INSERT, UPDATE, DELETE ON tinker_platform_release_files TO kyroco_publisher;
+REVOKE INSERT, UPDATE, DELETE ON tinker_platform_release_files FROM engram_app;
+CREATE TABLE tinker_promotion_audit (
+  audit_id        uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  CONSTRAINT tinker_promotion_audit_direction_chk
+    CHECK (direction IN ('promote','demote'))
+);
+";
+    let result = extract(source, "sql");
+    assert_eq!(
+        summary(&result.structure),
+        vec![(Some("tinker_platform_release_files"), &StructureKind::Struct, 0, 5)]
+    );
+    let table = &result.structure[0].span;
+    assert!(source[table.start_byte..table.end_byte].ends_with(");"));
+}
+
 const JUSTFILE: &str = "\
 set shell := [\"bash\", \"-eu\", \"-c\"]
 

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -1,14 +1,15 @@
 //! Declaration coverage for the code-shaped repository formats: SQL DDL,
-//! Justfiles and Dockerfiles. Their grammars name nodes the generic matcher
-//! misreads, so each has its own adapter, exercised here on the shapes real
-//! PostgreSQL bootstrap scripts, Justfiles and multi-stage Dockerfiles take.
+//! Justfiles, Dockerfiles, and C sources and headers. Their grammars name
+//! nodes the generic matcher misreads or never sees, so each has its own
+//! adapter, exercised here on the shapes real PostgreSQL bootstrap scripts,
+//! Justfiles, multi-stage Dockerfiles and C headers take.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 
 fn extract(source: &str, language: &str) -> ProcessResult {
     process(source, &ProcessConfig::new(language).all())
-        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just,dockerfile")
+        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just,dockerfile,c")
 }
 
 /// (name, kind, start_line, end_line) for each item, top level only.
@@ -369,4 +370,133 @@ fn dockerfile_named_stages_nest_their_args_and_env_pairs() {
     let stage = &result.structure[2].span;
     assert!(DOCKERFILE[stage.start_byte..stage.end_byte].ends_with("COPY . /app"));
     assert!(result.symbols.is_empty(), "Dockerfile emits no flat symbols");
+}
+
+const C_SOURCE: &str = "\
+#include <stdio.h>
+#define LIMIT 42
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define FLAG
+
+struct point {
+  int x;
+  int y;
+};
+
+typedef struct point point_t;
+
+typedef struct {
+  int w;
+} bare_t;
+
+typedef struct node {
+  struct node *next;
+} node_t;
+
+union number {
+  int i;
+  float f;
+};
+
+enum color { RED, GREEN };
+
+typedef enum { LOW, HIGH } level_t;
+
+typedef int (*callback_t)(int);
+
+static int counter = 0;
+const int limit = 3;
+extern int external;
+struct point origin = {0, 0};
+int (*fnptr)(int);
+
+static inline int helper(int v) {
+  struct local { int z; };
+  int inner = v;
+  return inner;
+}
+
+int prototype(int a);
+char *pointer_prototype(const char *s);
+
+int main(int argc, char **argv) {
+  return MAX(argc, LIMIT);
+}
+";
+
+#[test]
+fn c_definitions_prototypes_aggregates_typedefs_and_macros_are_declarations() {
+    let result = extract(C_SOURCE, "c");
+    assert_eq!(result.metrics.error_count, 0);
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("LIMIT"), &other("Constant"), 1, 1),
+            (Some("MAX"), &other("Macro"), 2, 2),
+            (Some("FLAG"), &other("Constant"), 3, 3),
+            (Some("point"), &StructureKind::Struct, 5, 8),
+            (Some("point_t"), &other("Type"), 10, 10),
+            (Some("bare_t"), &other("Type"), 12, 14),
+            (Some("node_t"), &other("Type"), 16, 18),
+            (Some("node"), &StructureKind::Struct, 16, 18),
+            (Some("number"), &other("Union"), 20, 23),
+            (Some("color"), &StructureKind::Enum, 25, 25),
+            (Some("level_t"), &other("Type"), 27, 27),
+            (Some("callback_t"), &other("Type"), 29, 29),
+            (Some("helper"), &StructureKind::Function, 37, 41),
+            (Some("prototype"), &StructureKind::Function, 43, 43),
+            (Some("pointer_prototype"), &StructureKind::Function, 44, 44),
+            (Some("main"), &StructureKind::Function, 46, 48),
+        ]
+    );
+    // ~keep A macro's span stops at its text, not at the newline the grammar swallows.
+    let limit = &result.structure[0].span;
+    assert_eq!(&C_SOURCE[limit.start_byte..limit.end_byte], "#define LIMIT 42");
+    // ~keep A top-level aggregate runs through its own terminator.
+    let point = &result.structure[3].span;
+    assert!(C_SOURCE[point.start_byte..point.end_byte].ends_with("};"));
+    assert!(result.structure.iter().all(|item| item.children.is_empty()));
+    assert!(result.symbols.is_empty(), "C emits no flat symbols");
+}
+
+const C_HEADER: &str = "\
+// A guarded header.
+#ifndef WIDGET_H
+#define WIDGET_H
+
+#ifdef __cplusplus
+extern \"C\" {
+#endif
+
+#if defined(WIDGET_SMALL)
+int widget_small(void);
+#else
+int widget_large(void);
+#endif
+
+void widget_free(char *pointer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+";
+
+#[test]
+fn c_header_guards_conditionals_and_linkage_blocks_are_transparent() {
+    let result = extract(C_HEADER, "c");
+    // ~keep The grammar pairs the `extern "C" {` brace across the `#endif` that
+    // ~keep closes its guard and reports one error node for it; the prototypes
+    // ~keep inside are parsed all the same, which is what this proves.
+    assert!(result.metrics.error_count <= 1);
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("WIDGET_H"), &other("Constant"), 2, 2),
+            (Some("widget_small"), &StructureKind::Function, 9, 9),
+            (Some("widget_large"), &StructureKind::Function, 11, 11),
+            (Some("widget_free"), &StructureKind::Function, 14, 14),
+        ]
+    );
 }

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -1,13 +1,14 @@
-//! Declaration coverage for the code-shaped repository formats. Their grammars
-//! name nodes the generic matcher misreads, so each has its own adapter,
-//! exercised here on the shapes real repository files take.
+//! Declaration coverage for the code-shaped repository formats: SQL DDL,
+//! Justfiles and Dockerfiles. Their grammars name nodes the generic matcher
+//! misreads, so each has its own adapter, exercised here on the shapes real
+//! PostgreSQL bootstrap scripts, Justfiles and multi-stage Dockerfiles take.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 
 fn extract(source: &str, language: &str) -> ProcessResult {
     process(source, &ProcessConfig::new(language).all())
-        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just")
+        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just,dockerfile")
 }
 
 /// (name, kind, start_line, end_line) for each item, top level only.
@@ -228,4 +229,67 @@ fn justfile_recipes_aliases_and_modules_are_declarations_with_trimmed_spans() {
     assert!(JUSTFILE[build.start_byte..build.end_byte].starts_with("[group("));
     assert!(JUSTFILE[build.start_byte..build.end_byte].ends_with("echo done"));
     assert!(result.symbols.is_empty(), "Just emits no flat symbols");
+}
+
+const DOCKERFILE: &str = "\
+# syntax=docker/dockerfile:1
+ARG ERLANG_VERSION=29.0.3
+ARG DEBIAN_VERSION=bookworm
+FROM hexpm/erlang:${ERLANG_VERSION}-debian-${DEBIAN_VERSION} AS toolchain_base
+ARG ELIXIR_VERSION
+ENV MIX_ENV=${MIX_ENV} \\
+    LANG=C.UTF-8
+RUN apt-get update \\
+  && apt-get install -y git
+COPY . /app
+
+# The next stage.
+FROM toolchain_base AS deps_base
+WORKDIR /app
+ENV RUSTUP_HOME=/opt/rustup
+FROM debian:${DEBIAN_VERSION}-slim as runtime_api
+ARG MIX_ENV
+ENV LANG C.UTF-8
+FROM nginx:1.27-alpine
+ARG MIX_ENV
+CMD [\"nginx\"]
+";
+
+#[test]
+fn dockerfile_named_stages_nest_their_args_and_env_pairs() {
+    let result = extract(DOCKERFILE, "dockerfile");
+    assert_eq!(result.metrics.error_count, 0);
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("ERLANG_VERSION"), &other("Constant"), 1, 1),
+            (Some("DEBIAN_VERSION"), &other("Constant"), 2, 2),
+            (Some("toolchain_base"), &StructureKind::Module, 3, 9),
+            (Some("deps_base"), &StructureKind::Module, 12, 14),
+            (Some("runtime_api"), &StructureKind::Module, 15, 17),
+            (Some("MIX_ENV"), &other("Constant"), 19, 19),
+        ]
+    );
+    assert_eq!(
+        summary(&result.structure[2].children),
+        vec![
+            (Some("ELIXIR_VERSION"), &other("Constant"), 4, 4),
+            (Some("MIX_ENV"), &other("Constant"), 5, 6),
+            (Some("LANG"), &other("Constant"), 5, 6),
+        ]
+    );
+    assert_eq!(
+        summary(&result.structure[3].children),
+        vec![(Some("RUSTUP_HOME"), &other("Constant"), 14, 14)]
+    );
+    assert_eq!(
+        summary(&result.structure[4].children),
+        vec![
+            (Some("MIX_ENV"), &other("Constant"), 16, 16),
+            (Some("LANG"), &other("Constant"), 17, 17),
+        ]
+    );
+    let stage = &result.structure[2].span;
+    assert!(DOCKERFILE[stage.start_byte..stage.end_byte].ends_with("COPY . /app"));
+    assert!(result.symbols.is_empty(), "Dockerfile emits no flat symbols");
 }

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -1,15 +1,16 @@
 //! Declaration coverage for the code-shaped repository formats: SQL DDL,
-//! Justfiles, Dockerfiles, and C sources and headers. Their grammars name
-//! nodes the generic matcher misreads or never sees, so each has its own
-//! adapter, exercised here on the shapes real PostgreSQL bootstrap scripts,
-//! Justfiles, multi-stage Dockerfiles and C headers take.
+//! Justfiles, Dockerfiles, C sources and headers, and Cedar policies. Their
+//! grammars name nodes the generic matcher misreads or never sees, so each
+//! has its own adapter, exercised here on the shapes real PostgreSQL
+//! bootstrap scripts, Justfiles, multi-stage Dockerfiles, C headers and
+//! policy sets take.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 
 fn extract(source: &str, language: &str) -> ProcessResult {
     process(source, &ProcessConfig::new(language).all())
-        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just,dockerfile,c")
+        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just,dockerfile,c,cedar")
 }
 
 /// (name, kind, start_line, end_line) for each item, top level only.
@@ -499,4 +500,46 @@ fn c_header_guards_conditionals_and_linkage_blocks_are_transparent() {
             (Some("widget_free"), &StructureKind::Function, 14, 14),
         ]
     );
+}
+
+const CEDAR: &str = "\
+// leading comment with @id(\"not_a_policy\") in it
+@id(\"allow_read\")
+@note(\"first\")
+permit(principal, action == Action::\"read\", resource);
+
+@id(\"deny_delete\")
+forbid(
+  principal,
+  action == Action::\"delete\",
+  resource
+)
+when { principal.role == \"guest\" };
+
+permit(principal, action, resource);
+
+@id(\"templated\")
+permit(principal == ?principal, action, resource in ?resource);
+
+@id(\"allow_read\")
+permit(principal, action == Action::\"list\", resource) unless { resource.locked };
+";
+
+#[test]
+fn cedar_policies_are_named_by_their_id_annotation() {
+    let result = extract(CEDAR, "cedar");
+    assert_eq!(result.metrics.error_count, 0);
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("allow_read"), &other("Policy"), 1, 3),
+            (Some("deny_delete"), &other("Policy"), 5, 11),
+            (Some("templated"), &other("Policy"), 15, 16),
+            (Some("allow_read"), &other("Policy"), 18, 19),
+        ]
+    );
+    let first = &result.structure[0].span;
+    assert!(CEDAR[first.start_byte..first.end_byte].starts_with("@id(\"allow_read\")"));
+    assert!(CEDAR[first.start_byte..first.end_byte].ends_with("resource);"));
+    assert!(result.symbols.is_empty(), "Cedar emits no flat symbols");
 }

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -6,7 +6,8 @@
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 
 fn extract(source: &str, language: &str) -> ProcessResult {
-    process(source, &ProcessConfig::new(language).all()).expect("real grammar required; build with TSLP_LANGUAGES=sql")
+    process(source, &ProcessConfig::new(language).all())
+        .expect("real grammar required; build with TSLP_LANGUAGES=sql,just")
 }
 
 /// (name, kind, start_line, end_line) for each item, top level only.
@@ -172,4 +173,59 @@ CREATE FUNCTION %s(%s) RETURNS %s;
         summary(&result.structure),
         vec![(Some("counted"), &StructureKind::Function, 0, 8)]
     );
+}
+
+const JUSTFILE: &str = "\
+set shell := [\"bash\", \"-eu\", \"-c\"]
+
+mod kyroco 'justfiles/kyroco.just'
+import 'other.just'
+
+MIX := \"/opt/homebrew/bin/mix\"
+
+# Run the proof.
+[private]
+default:
+    @just --list
+
+pre-pr *args:
+    cd {{DIR}} && ./scripts/pre-pr.sh {{args}}
+
+alias pp := pre-pr
+
+[group(\"ci\")]
+@build target=\"debug\" flag: deps compile
+    echo {{target}}
+    echo done
+
+_hidden:
+    echo hidden
+
+deps:
+    mix deps.get
+compile: deps
+    mix compile
+";
+
+#[test]
+fn justfile_recipes_aliases_and_modules_are_declarations_with_trimmed_spans() {
+    let result = extract(JUSTFILE, "just");
+    assert_eq!(result.metrics.error_count, 0);
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("kyroco"), &StructureKind::Module, 2, 2),
+            (Some("default"), &StructureKind::Function, 8, 10),
+            (Some("pre-pr"), &StructureKind::Function, 12, 13),
+            (Some("pp"), &other("Alias"), 15, 15),
+            (Some("build"), &StructureKind::Function, 17, 20),
+            (Some("_hidden"), &StructureKind::Function, 22, 23),
+            (Some("deps"), &StructureKind::Function, 25, 26),
+            (Some("compile"), &StructureKind::Function, 27, 28),
+        ]
+    );
+    let build = &result.structure[4].span;
+    assert!(JUSTFILE[build.start_byte..build.end_byte].starts_with("[group("));
+    assert!(JUSTFILE[build.start_byte..build.end_byte].ends_with("echo done"));
+    assert!(result.symbols.is_empty(), "Just emits no flat symbols");
 }

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -4,7 +4,7 @@
 //! has its own adapter, exercised here on the shapes real PostgreSQL
 //! bootstrap scripts, Justfiles, multi-stage Dockerfiles, C headers and
 //! policy sets take.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)] // ~keep: a failed setup step in a test must abort loudly
 
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -5,6 +5,7 @@
 //! bootstrap scripts, Justfiles, multi-stage Dockerfiles, C headers and
 //! policy sets take.
 #![allow(clippy::unwrap_used, clippy::expect_used)] // ~keep: a failed setup step in a test must abort loudly
+#![allow(clippy::print_stdout)] // ~keep: the deep-declarator probe reports to its parent process on stdout
 
 use tree_sitter_language_pack::{ProcessConfig, ProcessResult, StructureItem, StructureKind, process};
 
@@ -499,6 +500,72 @@ fn c_header_guards_conditionals_and_linkage_blocks_are_transparent() {
             (Some("widget_large"), &StructureKind::Function, 11, 11),
             (Some("widget_free"), &StructureKind::Function, 14, 14),
         ]
+    );
+}
+
+/// Set by the parent test so the child process runs the deep-declarator probe for real.
+const C_DEEP_DECLARATOR_PROBE_ENV: &str = "TSLP_C_DEEP_DECLARATOR_PROBE";
+const C_DEEP_DECLARATOR_STARS: usize = 100_000;
+const C_DEEP_DECLARATOR_SENTINEL: &str = "c deep declarator probe completed";
+
+/// The probe itself. Ignored so a plain run never executes it in-process: a stack
+/// overflow is an abort, not a panic, and would take every other test in this
+/// binary down with it. The parent below re-executes this binary with the env var
+/// set and asks for exactly this test.
+#[test]
+#[ignore]
+fn c_deep_declarator_probe() {
+    if std::env::var_os(C_DEEP_DECLARATOR_PROBE_ENV).is_none() {
+        return;
+    }
+    let stars = "*".repeat(C_DEEP_DECLARATOR_STARS);
+    // ~keep One prototype, one variable and one typedef, each behind the same
+    // ~keep pointer chain: the prototype and the typedef walk the chain to their
+    // ~keep name, the variable walks it to learn it declares nothing.
+    let source = format!("int {stars}deep(void);\nint {stars}name;\ntypedef int {stars}alias;\n");
+    // ~keep 2 MiB is the smallest stack the library runs on (tokio spawn_blocking and the
+    // ~keep Node, Python and JVM worker threads); the default test thread is not that small.
+    let worker = std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let result = extract(&source, "c");
+            (result.metrics.error_count, result.structure)
+        })
+        .expect("spawn probe thread");
+    let (errors, items) = worker.join().expect("probe thread must not panic");
+    assert_eq!(errors, 0, "the fixture must parse cleanly for the chain to be real");
+    assert_eq!(
+        summary(&items),
+        vec![
+            (Some("deep"), &StructureKind::Function, 0, 0),
+            (Some("alias"), &other("Type"), 2, 2),
+        ]
+    );
+    println!("{C_DEEP_DECLARATOR_SENTINEL}");
+}
+
+/// A declarator wrapped in 100,000 pointers must not abort the process.
+///
+/// The C grammar nests one `pointer_declarator` per `*`, so a name finder that
+/// recurses per level walks off a 2 MiB stack long before the depth guard the
+/// item walk shares can see it. An abort cannot be caught in-process, so the
+/// probe runs in a child and this test reads its exit status and its sentinel line;
+/// the sentinel is what stops a filtered-out or silently skipped probe from passing
+/// as a survival.
+#[test]
+fn c_deep_declarator_survives_a_two_mebibyte_stack() {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = std::process::Command::new(exe)
+        .args(["--ignored", "--exact", "c_deep_declarator_probe", "--nocapture"])
+        .env(C_DEEP_DECLARATOR_PROBE_ENV, "1")
+        .output()
+        .expect("spawn the probe child process");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success() && stdout.contains(C_DEEP_DECLARATOR_SENTINEL),
+        "the deep declarator probe did not survive (status {:?})\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status
     );
 }
 

--- a/crates/ts-pack-core/tests/code_shaped_declarations.rs
+++ b/crates/ts-pack-core/tests/code_shaped_declarations.rs
@@ -461,6 +461,35 @@ fn c_definitions_prototypes_aggregates_typedefs_and_macros_are_declarations() {
     assert!(result.symbols.is_empty(), "C emits no flat symbols");
 }
 
+/// C spells a function declaration more than one way, and requiring the
+/// function declarator to apply to a bare identifier saw only the plainest.
+/// A redundant pair of parentheses around the name is legal, and a function
+/// returning a function pointer puts its name under an inner declarator.
+/// Neither is a variable, and the function pointer variable that shares their
+/// shape still is.
+#[test]
+fn c_prototypes_behind_parentheses_and_returned_function_pointers_are_functions() {
+    let source = "\
+int (parenthesised)(int);
+int (*factory(void))(int);
+char *(*table_lookup(const char *key))(int, int);
+int (*variable)(int);
+int (*table[4])(int);
+extern int external;
+";
+    let result = extract(source, "c");
+    assert_eq!(
+        summary(&result.structure),
+        vec![
+            (Some("parenthesised"), &StructureKind::Function, 0, 0),
+            (Some("factory"), &StructureKind::Function, 1, 1),
+            (Some("table_lookup"), &StructureKind::Function, 2, 2),
+        ],
+        "a redundant parenthesis and a returned function pointer declare functions; \
+         a function pointer variable, an array of them and a scalar declare none"
+    );
+}
+
 const C_HEADER: &str = "\
 // A guarded header.
 #ifndef WIDGET_H

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -287,6 +287,100 @@ fn xml_that_is_not_a_plist_keeps_its_element_paths() {
     assert_eq!(root.children[0].children[0].key.as_deref(), Some("key"));
 }
 
+/// A text run is not one node: an entity reference, a character reference and
+/// a CDATA section each split it, and CDATA hangs below a `CDSect` rather
+/// than beside the text. Reading the first child alone truncated a key at its
+/// first `&` and read a CDATA value as empty.
+#[test]
+fn plist_text_survives_entities_character_references_and_cdata() {
+    let source = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<plist version=\"1.0\">
+<dict>
+  <key>A&amp;B</key>
+  <string>left&amp;right</string>
+  <key>Cdata</key>
+  <string><![CDATA[raw <tag> & text]]></string>
+  <key>Mixed</key>
+  <string>before<![CDATA[ middle ]]>after</string>
+  <key>Numeric</key>
+  <string>a&#65;b&#x42;c</string>
+  <key>Unknown</key>
+  <string>x&nbsp;y</string>
+</dict>
+</plist>
+";
+    let root = data(source, "xml");
+    let entries: Vec<(Option<&str>, Option<&str>)> = root
+        .children
+        .iter()
+        .map(|entry| (entry.key.as_deref(), entry.value.as_deref()))
+        .collect();
+    assert_eq!(
+        entries,
+        vec![
+            // The key keeps the whole run, so it is not renamed to "A".
+            (Some("A&B"), Some("left&right")),
+            (Some("Cdata"), Some("raw <tag> & text")),
+            (Some("Mixed"), Some("before middle after")),
+            (Some("Numeric"), Some("aAbBc")),
+            // An entity this reader cannot resolve without the DTD is kept as
+            // written rather than dropped, which would lose text silently.
+            (Some("Unknown"), Some("x&nbsp;y")),
+        ]
+    );
+}
+
+/// Whitespace inside a property list `<string>` is part of the value, so it
+/// is carried; a `<key>` and the scalars an XML writer may indent onto their
+/// own line are names and still trim.
+#[test]
+fn plist_string_values_keep_their_whitespace_and_keys_do_not() {
+    let source = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<plist version=\"1.0\">
+<dict>
+  <key>  Padded Key  </key>
+  <string>  padded value  </string>
+  <key>Number</key>
+  <integer>
+    42
+  </integer>
+</dict>
+</plist>
+";
+    let root = data(source, "xml");
+    let entries: Vec<(Option<&str>, Option<&str>)> = root
+        .children
+        .iter()
+        .map(|entry| (entry.key.as_deref(), entry.value.as_deref()))
+        .collect();
+    assert_eq!(
+        entries,
+        vec![
+            (Some("Padded Key"), Some("  padded value  ")),
+            (Some("Number"), Some("42")),
+        ]
+    );
+}
+
+/// The same truncation lived a second time, inlined, in the generic XML
+/// reader, where the maintainer's review did not reach it.
+#[test]
+fn generic_xml_element_text_survives_entities_and_cdata() {
+    let root = data("<r><a>one&amp;two</a><b><![CDATA[cdata body]]></b></r>\n", "xml");
+    let element = &root.children[0];
+    let values: Vec<(Option<&str>, Option<&str>)> = element
+        .children
+        .iter()
+        .map(|child| (child.key.as_deref(), child.value.as_deref()))
+        .collect();
+    assert_eq!(
+        values,
+        vec![(Some("a"), Some("one&two")), (Some("b"), Some("cdata body"))]
+    );
+}
+
 #[test]
 fn dotenv_assignments_are_keyed_scalars_with_values_as_written() {
     let source = "\

--- a/crates/ts-pack-core/tests/configuration_nodes.rs
+++ b/crates/ts-pack-core/tests/configuration_nodes.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // ~keep: a failed setup step in a test must abort loudly
 #![allow(clippy::print_stdout)] // ~keep: the deep-key probe reports to its parent process on stdout
 
-use tree_sitter_language_pack::{DataNode, ProcessConfig, process};
+use tree_sitter_language_pack::{DataNode, DataNodeKind, ProcessConfig, process};
 
 fn data(source: &str, language: &str) -> DataNode {
     process(source, &ProcessConfig::new(language).with_data_extraction(true))
@@ -223,5 +223,106 @@ fn toml_deep_dotted_key_survives_a_two_mebibyte_stack() {
         output.status.success() && stdout.contains(TOML_DEEP_KEY_SENTINEL),
         "the deep dotted key probe did not survive (status {:?})\nstdout:\n{stdout}\nstderr:\n{stderr}",
         output.status
+    );
+}
+
+#[test]
+fn plist_dict_entries_are_keyed_by_their_key_text_and_arrays_by_position() {
+    let source = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<array>
+  <dict>
+    <key>BundleIsRelocatable</key>
+    <false/>
+    <key>BundleOverwriteAction</key>
+    <string>upgrade</string>
+    <key>Paths</key>
+    <array>
+      <string>one</string>
+      <string>two</string>
+    </array>
+  </dict>
+</array>
+</plist>
+";
+    let root = data(source, "xml");
+    assert_eq!(root.children.len(), 1);
+    let item = &root.children[0];
+    assert_eq!(item.key.as_deref(), Some("0"));
+    assert_eq!(item.kind, DataNodeKind::Sequence);
+    assert_eq!(item.value, None);
+    assert_eq!((item.span.start_line, item.span.end_line), (4, 14));
+    let entries: Vec<(Option<&str>, Option<&str>, usize, usize)> = item
+        .children
+        .iter()
+        .map(|entry| {
+            (
+                entry.key.as_deref(),
+                entry.value.as_deref(),
+                entry.span.start_line,
+                entry.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        entries,
+        vec![
+            (Some("BundleIsRelocatable"), Some("false"), 5, 6),
+            (Some("BundleOverwriteAction"), Some("upgrade"), 7, 8),
+            (Some("Paths"), None, 9, 13),
+        ]
+    );
+    let paths = &item.children[2].children;
+    assert_eq!(paths.len(), 2);
+    assert_eq!(paths[1].key.as_deref(), Some("1"));
+    assert_eq!(paths[1].value.as_deref(), Some("two"));
+}
+
+#[test]
+fn xml_that_is_not_a_plist_keeps_its_element_paths() {
+    let root = data("<plist-like><key>Name</key></plist-like>\n", "xml");
+    assert_eq!(root.children[0].key.as_deref(), Some("plist-like"));
+    assert_eq!(root.children[0].children[0].key.as_deref(), Some("key"));
+}
+
+#[test]
+fn dotenv_assignments_are_keyed_scalars_with_values_as_written() {
+    let source = "\
+# comment KEY=IGNORED
+PLAIN=value
+export EXPORTED=1
+EMPTY=
+PLACEHOLDER=${OTHER}
+MULTI=\"line one
+line two\"
+DUP=1
+DUP=2
+";
+    let root = data(source, "dotenv");
+    let entries: Vec<(Option<&str>, Option<&str>, usize, usize)> = root
+        .children
+        .iter()
+        .map(|entry| {
+            (
+                entry.key.as_deref(),
+                entry.value.as_deref(),
+                entry.span.start_line,
+                entry.span.end_line,
+            )
+        })
+        .collect();
+    assert_eq!(
+        entries,
+        vec![
+            (Some("PLAIN"), Some("value"), 1, 1),
+            (Some("EXPORTED"), Some("1"), 2, 2),
+            (Some("EMPTY"), Some(""), 3, 3),
+            (Some("PLACEHOLDER"), Some("${OTHER}"), 4, 4),
+            (Some("MULTI"), Some("\"line one\nline two\""), 5, 6),
+            (Some("DUP"), Some("1"), 7, 7),
+            (Some("DUP"), Some("2"), 8, 8),
+        ]
     );
 }


### PR DESCRIPTION
I'd like to contribute back to the community with these parsers Kyroco maintains for our product. Happy to have you absorb them in your repo if you think they're useful and can benefit the community. Also, thank you for merging PR #186 so quickly, and this PR builds on it. These are declarations for a set of code-shaped formats intel returns nothing for right now. Tests included of course.

## Related

None that we could find. Happy to open issues if you would like these tracked, just let me know.

## Description

New per-format adapters under `intel/`, each routed from `extract.rs` for its language only, with the generic structure matcher switched off where the grammar's node names would mislead it:

- **SQL** (`sql.rs`): tables, views and materialized views, functions and procedures, schemas, types, indexes, triggers, policies and roles, schema-qualified where the statement is, quoted identifiers unquoted. Statements the grammar folds into ERROR nodes (a GRANT, a DO block, a psql meta-command, a SET inside a function header) are recovered from the token stream, and a routine's span ends at the closing dollar quote of its own tag rather than running into the next statement. The generic matcher is off for SQL, because the grammar names a plpgsql DECLARE variable `function_declaration`.
- **Justfile** (`just.rs`): recipes as functions with their attributes, dependencies and body, aliases, and `mod` declarations; settings, assignments and imports produce nothing.
- **Dockerfile** (`dockerfile.rs`): a named `FROM ... AS` stage as a module spanning through its last instruction, with the `ARG` and `ENV` names declared inside it nested underneath.
- **C** (`c.rs`): function definitions and prototypes, structs, enums, unions, typedefs, and object-like and function-like macros; nothing inside a function body. The declarator walkers are iterative, following the lesson from the #186 review: a name behind 100,000 pointers is a valid parse, and the last commit adds a child-process probe on a 2 MiB stack for it, in the shape of the TOML dotted-key probe.
- **Cedar** (`cedar.rs`): each policy named by its `@id`, spanning from its first annotation through the terminator; a policy with no id produces nothing.
- **dotenv and property lists** (`data_extraction.rs`): dotenv assignments as data nodes keyed by variable name, and an XML document whose root is `<plist>` read by its `<key>` text so a plist arrives keyed like a mapping.

The five structure adapters walk the tree through the shared bounded walker, and the plist reader carries the same depth guard as the other data readers. No grammar, query pack or DataNode schema changes.

## Validation

Run on the branch rebased onto `main` at 72a6c3cb0a (1.17.0), with Alef 0.85.11:

- `TSLP_LINK_MODE=static TSLP_LANGUAGES=sql,just,dockerfile,c,cedar cargo test -p tree-sitter-language-pack --test code_shaped_declarations`: 11 passed, 1 ignored (the ignored test is the deep-declarator probe, which its parent test runs in a child process)
- `TSLP_LINK_MODE=static TSLP_LANGUAGES=yaml,toml,json,terraform,hcl,xml,dotenv cargo test -p tree-sitter-language-pack --test configuration_nodes`: 16 passed, 1 ignored (the TOML dotted-key probe, same arrangement)
- `cargo test -p tree-sitter-language-pack` and the `test-internals,serde,config` feature run, with 20 grammars built in statically: every suite passes except the ones that download grammars from the 1.17.0 release, whose `parsers.json` was not published yet when this ran; CI will cover those
- `cargo clippy --locked --workspace --exclude ts-pack-core-wasm -- -D warnings` (the CI form) and `cargo clippy --workspace --all-targets -- -D warnings`: clean (the PHP crate excluded locally, php is not installed here)
- `cargo fmt --all -- --check`: clean
- `alef verify --exit-code` (0.85.11): all bindings and versions up to date, generation fingerprint unchanged
- `poly lint` and `poly fmt --check` on every file the branch touches: clean

Every new test failed before its adapter and passes after, against the real parsers: 12 tests in `code_shaped_declarations.rs` (11 in-process plus the child-process probe) and 3 in `configuration_nodes.rs`. Downstream, the same adapter code runs in our macOS client and our server as a crate of our own, and the shared fixtures the two check against each other pass on both.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable (15 new tests: 12 in `code_shaped_declarations.rs`, 3 in `configuration_nodes.rs`)

Thanks again,
Robert
